### PR TITLE
Fix argument ordering in getMinBufferSize

### DIFF
--- a/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
+++ b/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
@@ -95,8 +95,8 @@ class MainActivity : AppCompatActivity() {
 
         val bufferSize = AudioTrack.getMinBufferSize(
             audioFormat.sampleRate,
-            audioFormat.encoding,
-            audioFormat.channelMask
+            audioFormat.channelMask,
+            audioFormat.encoding
         )
 
         return AudioTrack(


### PR DESCRIPTION
[Signature](https://developer.android.com/reference/android/media/AudioRecord#getMinBufferSize(int,%20int,%20int)) is

    public static int getMinBufferSize (int sampleRateInHz, 
                    int channelConfig, 
                    int audioFormat)

and the code is mistakenly swapping the last two arguments. Yay untyped integers :(