### PR TITLE
Fix volume is ignored

### DIFF
--- a/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
+++ b/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
@@ -203,9 +203,7 @@ class MainActivity : AppCompatActivity() {
     private fun createAudioTrack(): AudioTrack {
         val audioAttributes = AudioAttributes.Builder().apply {
             setUsage(AudioAttributes.USAGE_MEDIA)
-            setLegacyStreamType(AudioManager.STREAM_SYSTEM)
             setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-            setFlags(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
         }.build()
         val audioFormat = AudioFormat.Builder().apply {
             setSampleRate(SAMPLE_RATE)
@@ -217,13 +215,14 @@ class MainActivity : AppCompatActivity() {
             audioFormat.channelMask,
             audioFormat.encoding
         )
-        return AudioTrack(
-            audioAttributes,
-            audioFormat,
-            bufferSize,
-            AudioTrack.MODE_STREAM,
-            AudioManager.AUDIO_SESSION_ID_GENERATE
-        )
+        return AudioTrack.Builder().apply {
+            setAudioAttributes(audioAttributes)
+            setAudioFormat(audioFormat)
+            setBufferSizeInBytes(bufferSize)
+            setTransferMode(AudioTrack.MODE_STREAM)
+            setSessionId(AudioManager.AUDIO_SESSION_ID_GENERATE)
+            setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
+        }.build()
     }
 
     private fun createAudioRecord(): AudioRecord {


### PR DESCRIPTION
This fixes #3.

When running this I was confused why I wasn't hearing any audio when I knew there was audio being received. It turns out it was using notification volume instead of media volume and I had my device on dnd.

One of the causes of this was with `setLegacyStreamType(AudioManager.STREAM_SYSTEM)`. The [docs](https://developer.android.com/reference/kotlin/android/media/AudioAttributes.Builder#setlegacystreamtype) say it should not be used with any other attributes as it overwrites the previously set values and to just set the attributes instead of using the legacy stream type. This was overwriting the previously set attribute `setUsage(AudioAttributes.USAGE_MEDIA)`. Removing this fixed the issue on my device running Android 11.

I then ran it on a different device running Android 8.1 and it wasn't working again 🤦‍♂️. This time it was due to `setFlags(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)`. This was [deprecated](https://developer.android.com/reference/kotlin/android/media/AudioAttributes#flag_low_latency) and should be set with [AudioTrack.Builder.setPerformanceMode](https://developer.android.com/reference/kotlin/android/media/AudioTrack.Builder#setperformancemode). I don't know why it was causing this issue but changing it to use this fixed it.