### PR TITLE
Add foreground service with notification for the current sending and receiving state

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
     <application
         android:allowBackup="true"
@@ -13,7 +14,14 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <service
+            android:name=".SenderReceiverService"
+            android:exported="false"
+            />
+
+        <activity
+            android:name=".MainActivity"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
+++ b/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
@@ -1,9 +1,13 @@
 package org.rocstreaming.rocdroid
 
 import android.Manifest
+import android.content.ComponentName
+import android.content.Intent
+import android.content.ServiceConnection
 import android.content.pm.PackageManager
-import android.media.*
+import android.media.AudioManager
 import android.os.Bundle
+import android.os.IBinder
 import android.text.Html
 import android.view.View
 import android.widget.Button
@@ -14,21 +18,27 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import org.rocstreaming.roctoolkit.*
 import java.net.NetworkInterface
 
-private const val SAMPLE_RATE = 44100
-private const val BUFFER_SIZE = 100
-
-private const val RTP_PORT_SOURCE = 11001
-private const val RTP_PORT_REPAIR = 11002
-
 class MainActivity : AppCompatActivity() {
-    private var receiverThread: Thread? = null
-    private var senderThread: Thread? = null
 
     private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
     private lateinit var receiverIpEdit: EditText
+    private lateinit var senderReceiverService: SenderReceiverService
+
+    private val senderReceiverServiceConnection = object : ServiceConnection {
+
+        override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
+            senderReceiverService = (binder as SenderReceiverService.LocalBinder).getService()
+            senderReceiverService.setStateChangedListeners(
+                senderChanged = { state: Boolean -> runOnUiThread { setSenderButtonState(state) } },
+                receiverChanged = { state: Boolean -> runOnUiThread { setReceiverButtonState(state) } })
+        }
+
+        override fun onServiceDisconnected(componentName: ComponentName) {
+            senderReceiverService.removeListeners()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,6 +61,9 @@ class MainActivity : AppCompatActivity() {
                     }.show()
                 }
             }
+
+        val serviceIntent = Intent(this, SenderReceiverService::class.java)
+        bindService(serviceIntent, senderReceiverServiceConnection, BIND_AUTO_CREATE)
     }
 
     override fun onResume() {
@@ -58,123 +71,31 @@ class MainActivity : AppCompatActivity() {
         volumeControlStream = AudioManager.STREAM_MUSIC
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        unbindService(senderReceiverServiceConnection)
+    }
+
     /**
      * Start roc receiver in separated thread and play samples via audioTrack
      */
     fun startStopReceiver(@Suppress("UNUSED_PARAMETER") view: View) {
-        if (receiverThread?.isAlive == true) {
-            receiverThread?.interrupt()
+        if (senderReceiverService.isReceiverAlive()) {
+            senderReceiverService.stopReceiver()
         } else {
-            startReceiver()
+            senderReceiverService.startReceiver()
         }
-        setReceiverButtonState()
-    }
-
-    private fun startReceiver() {
-        if (receiverThread?.isAlive == true) return
-
-        receiverThread = Thread(Runnable {
-            val audioTrack = createAudioTrack()
-            audioTrack.play()
-
-            val config = ReceiverConfig.Builder(
-                SAMPLE_RATE,
-                ChannelSet.STEREO,
-                FrameEncoding.PCM_FLOAT
-            ).build()
-
-            Context().use { context ->
-                Receiver(context, config).use { receiver ->
-                    receiver.bind(
-                        PortType.AUDIO_SOURCE,
-                        Protocol.RTP_RS8M_SOURCE,
-                        Address(Family.AUTO, "0.0.0.0", 10001)
-                    )
-                    receiver.bind(
-                        PortType.AUDIO_REPAIR,
-                        Protocol.RS8M_REPAIR,
-                        Address(Family.AUTO, "0.0.0.0", 10002)
-                    )
-
-                    val samples = FloatArray(BUFFER_SIZE)
-                    while (!Thread.currentThread().isInterrupted) {
-                        receiver.read(samples)
-                        audioTrack.write(samples, 0, samples.size, AudioTrack.WRITE_BLOCKING)
-                    }
-                }
-            }
-
-            audioTrack.release()
-        })
-
-        receiverThread!!.start()
     }
 
     fun startStopSender(@Suppress("UNUSED_PARAMETER") view: View?) {
-        if (senderThread?.isAlive == true) {
-            senderThread?.interrupt()
+        if (senderReceiverService.isSenderAlive()) {
+            senderReceiverService.stopSender()
         } else {
-            startSender()
+            if (!askForRecordAudioPermission()) return
+
+            val ip = receiverIpEdit.text.toString()
+            senderReceiverService.startSender(ip)
         }
-        setSenderButtonState()
-    }
-
-    fun startSender() {
-        if (senderThread?.isAlive == true) return
-
-        if (!askForRecordAudioPermission()) return
-
-        val ip = receiverIpEdit.text.toString()
-
-        senderThread = Thread(Runnable {
-            val record = createAudioRecord()
-
-            val config = SenderConfig.Builder(
-                SAMPLE_RATE,
-                ChannelSet.STEREO,
-                FrameEncoding.PCM_FLOAT
-            ).build()
-
-            Context().use { context ->
-                if (record.state != AudioRecord.STATE_INITIALIZED) return@use
-
-                record.startRecording()
-
-                Sender(context, config).use { sender ->
-                    sender.bind(Address(Family.AUTO, "0.0.0.0", 0))
-
-                    try {
-                        sender.connect(
-                            PortType.AUDIO_SOURCE, Protocol.RTP_RS8M_SOURCE,
-                            Address(Family.AUTO, ip, RTP_PORT_SOURCE)
-                        )
-                        sender.connect(
-                            PortType.AUDIO_REPAIR, Protocol.RS8M_REPAIR,
-                            Address(Family.AUTO, ip, RTP_PORT_REPAIR)
-                        )
-                    } catch (e: Exception) {
-                        AlertDialog.Builder(this@MainActivity).apply {
-                            setTitle(getString(R.string.invalid_ip_title))
-                            setMessage(getString(R.string.invalid_ip_message))
-                            setCancelable(false)
-                            setPositiveButton(R.string.ok) { _, _ -> }
-                        }.show()
-                        return@use
-                    }
-
-                    val samples = FloatArray(BUFFER_SIZE)
-                    while (!Thread.currentThread().isInterrupted) {
-                        record.read(samples, 0, samples.size, AudioRecord.READ_BLOCKING)
-                        sender.write(samples)
-                    }
-                }
-
-                record.stop()
-                record.release()
-            }
-        })
-
-        senderThread!!.start()
     }
 
     private fun askForRecordAudioPermission(): Boolean = when {
@@ -200,48 +121,6 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private fun createAudioTrack(): AudioTrack {
-        val audioAttributes = AudioAttributes.Builder().apply {
-            setUsage(AudioAttributes.USAGE_MEDIA)
-            setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
-        }.build()
-        val audioFormat = AudioFormat.Builder().apply {
-            setSampleRate(SAMPLE_RATE)
-            setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
-            setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
-        }.build()
-        val bufferSize = AudioTrack.getMinBufferSize(
-            audioFormat.sampleRate,
-            audioFormat.channelMask,
-            audioFormat.encoding
-        )
-        return AudioTrack.Builder().apply {
-            setAudioAttributes(audioAttributes)
-            setAudioFormat(audioFormat)
-            setBufferSizeInBytes(bufferSize)
-            setTransferMode(AudioTrack.MODE_STREAM)
-            setSessionId(AudioManager.AUDIO_SESSION_ID_GENERATE)
-            setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
-        }.build()
-    }
-
-    private fun createAudioRecord(): AudioRecord {
-        val bufferSize = AudioRecord.getMinBufferSize(
-            SAMPLE_RATE,
-            AudioFormat.CHANNEL_IN_STEREO,
-            AudioFormat.ENCODING_PCM_FLOAT
-        )
-        return AudioRecord.Builder().apply {
-            setAudioSource(MediaRecorder.AudioSource.DEFAULT)
-            setAudioFormat(AudioFormat.Builder().apply {
-                setChannelMask(AudioFormat.CHANNEL_IN_STEREO)
-                setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
-                setSampleRate(SAMPLE_RATE)
-            }.build())
-            setBufferSizeInBytes(bufferSize)
-        }.build()
-    }
-
     private fun getIpAddresses(): String {
         try {
             return NetworkInterface.getNetworkInterfaces().toList()
@@ -254,28 +133,27 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setButtonState(
-        thread: Thread?,
+        isRunning: Boolean,
         button: Int,
         startString: Int,
         stopString: Int
     ): Boolean {
-        val alive = thread?.isAlive == true && !thread.isInterrupted
-        findViewById<Button>(button).text = getText(if (alive) stopString else startString)
-        return alive
+        findViewById<Button>(button).text = getText(if (isRunning) stopString else startString)
+        return isRunning
     }
 
-    private fun setReceiverButtonState() {
+    private fun setReceiverButtonState(isRunning: Boolean) {
         setButtonState(
-            receiverThread,
+            isRunning,
             R.id.startReceiver,
             R.string.start_receiver,
             R.string.stop_receiver
         )
     }
 
-    private fun setSenderButtonState() {
+    private fun setSenderButtonState(isRunning: Boolean) {
         val alive = setButtonState(
-            senderThread,
+            isRunning,
             R.id.startSender,
             R.string.start_sender,
             R.string.stop_sender

--- a/app/src/main/java/org/rocstreaming/rocdroid/SenderReceiverService.kt
+++ b/app/src/main/java/org/rocstreaming/rocdroid/SenderReceiverService.kt
@@ -1,0 +1,323 @@
+package org.rocstreaming.rocdroid
+
+import android.app.*
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.graphics.drawable.Icon
+import android.media.*
+import android.os.Binder
+import android.os.IBinder
+import androidx.appcompat.app.AlertDialog
+import org.rocstreaming.roctoolkit.*
+
+private const val SAMPLE_RATE = 44100
+private const val BUFFER_SIZE = 100
+
+private const val RTP_PORT_SOURCE = 11001
+private const val RTP_PORT_REPAIR = 11002
+
+private const val CHANNEL_ID = "SenderReceiverService"
+private const val NOTIFICATION_ID = 1
+private const val BROADCAST_STOP_ACTION = "org.rocstreaming.rocdroid.NotificationStopAction"
+
+class SenderReceiverService : Service() {
+
+    private var receiverThread: Thread? = null
+    private var senderThread: Thread? = null
+    private var receiverChanged: ((Boolean) -> Unit)? = null
+    private var senderChanged: ((Boolean) -> Unit)? = null
+    private var isForegroundRunning = false
+
+    private val notificationStopActionReceiver: BroadcastReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            stopForegroundService()
+            stopSender()
+            stopReceiver()
+        }
+    }
+
+    private val binder = LocalBinder()
+
+    inner class LocalBinder : Binder() {
+        fun getService(): SenderReceiverService = this@SenderReceiverService
+    }
+
+    override fun onBind(intent: Intent): IBinder? {
+        return binder
+    }
+
+    override fun onCreate() {
+        createNotificationChannel()
+        registerReceiver(notificationStopActionReceiver, IntentFilter(BROADCAST_STOP_ACTION))
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        unregisterReceiver(notificationStopActionReceiver)
+    }
+
+    private fun createNotificationChannel() {
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            getString(R.string.notification_channel_name),
+            NotificationManager.IMPORTANCE_LOW
+        )
+        val service = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        service.createNotificationChannel(channel)
+    }
+
+    private fun buildNotification(sending: Boolean, receiving: Boolean): Notification {
+        val mainActivityIntent = Intent(this, MainActivity::class.java)
+        val pendingMainActivityIntent = PendingIntent.getActivity(
+            this,
+            0,
+            mainActivityIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val stopIntent = Intent(BROADCAST_STOP_ACTION)
+        val pendingStopIntent = PendingIntent.getBroadcast(
+            this@SenderReceiverService,
+            0,
+            stopIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        val stopAction = Notification.Action.Builder(
+            Icon.createWithResource(this@SenderReceiverService, R.drawable.ic_stop),
+            getString(R.string.notification_stop_action),
+            pendingStopIntent
+        ).build()
+        return Notification.Builder(this, CHANNEL_ID).apply {
+            setContentTitle(getString(R.string.notification_title))
+            setContentText(getContentText(sending, receiving))
+            setSmallIcon(R.drawable.ic_launcher_foreground)
+            setVisibility(Notification.VISIBILITY_PUBLIC)
+            setContentIntent(pendingMainActivityIntent)
+            addAction(stopAction)
+        }.build()
+    }
+
+    private fun updateNotification(sending: Boolean, receiving: Boolean) {
+        if (!isForegroundRunning) {
+            return
+        }
+
+        if (receiving || sending) {
+            val notification = buildNotification(sending, receiving)
+            val notificationManager =
+                getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.notify(NOTIFICATION_ID, notification)
+        } else {
+            stopForegroundService()
+        }
+    }
+
+    private fun getContentText(sending: Boolean, receiving: Boolean): String {
+        if (sending && receiving) {
+            return getString(R.string.notification_sender_and_receiver_running)
+        }
+        if (receiving) {
+            return getString(R.string.notification_receiver_running)
+        }
+        if (sending) {
+            return getString(R.string.notification_sender_running)
+        }
+        return getString(R.string.notification_sender_and_receiver_not_running)//this shouldn't happen
+    }
+
+    fun startSender(ip: String) {
+        if (senderThread?.isAlive == true) return
+
+        senderThread = Thread(Runnable {
+            val record = createAudioRecord()
+
+            val config = SenderConfig.Builder(
+                SAMPLE_RATE,
+                ChannelSet.STEREO,
+                FrameEncoding.PCM_FLOAT
+            ).build()
+
+            org.rocstreaming.roctoolkit.Context().use { context ->
+                if (record.state != AudioRecord.STATE_INITIALIZED) return@use
+
+                record.startRecording()
+
+                Sender(context, config).use { sender ->
+                    sender.bind(Address(Family.AUTO, "0.0.0.0", 0))
+
+                    try {
+                        sender.connect(
+                            PortType.AUDIO_SOURCE, Protocol.RTP_RS8M_SOURCE,
+                            Address(Family.AUTO, ip, RTP_PORT_SOURCE)
+                        )
+                        sender.connect(
+                            PortType.AUDIO_REPAIR, Protocol.RS8M_REPAIR,
+                            Address(Family.AUTO, ip, RTP_PORT_REPAIR)
+                        )
+                    } catch (e: Exception) {
+                        AlertDialog.Builder(this@SenderReceiverService).apply {
+                            setTitle(getString(R.string.invalid_ip_title))
+                            setMessage(getString(R.string.invalid_ip_message))
+                            setCancelable(false)
+                            setPositiveButton(R.string.ok) { _, _ -> }
+                        }.show()
+                        return@use
+                    }
+
+                    senderChanged?.invoke(true)
+
+                    val samples = FloatArray(BUFFER_SIZE)
+                    while (!Thread.currentThread().isInterrupted) {
+                        record.read(samples, 0, samples.size, AudioRecord.READ_BLOCKING)
+                        sender.write(samples)
+                    }
+                }
+
+                record.stop()
+                record.release()
+                senderChanged?.invoke(false)
+                updateNotification(false, isReceiverAlive())
+            }
+        })
+
+        senderThread!!.start()
+
+        if (isForegroundRunning) {
+            updateNotification(true, isReceiverAlive())
+        } else {
+            startForegroundService(true, isReceiverAlive())
+        }
+    }
+
+    fun startReceiver() {
+        if (receiverThread?.isAlive == true) return
+
+        receiverThread = Thread(Runnable {
+            val audioTrack = createAudioTrack()
+            audioTrack.play()
+
+            val config = ReceiverConfig.Builder(
+                SAMPLE_RATE,
+                ChannelSet.STEREO,
+                FrameEncoding.PCM_FLOAT
+            ).build()
+
+            org.rocstreaming.roctoolkit.Context().use { context ->
+                Receiver(context, config).use { receiver ->
+                    receiver.bind(
+                        PortType.AUDIO_SOURCE,
+                        Protocol.RTP_RS8M_SOURCE,
+                        Address(Family.AUTO, "0.0.0.0", 10001)
+                    )
+                    receiver.bind(
+                        PortType.AUDIO_REPAIR,
+                        Protocol.RS8M_REPAIR,
+                        Address(Family.AUTO, "0.0.0.0", 10002)
+                    )
+
+                    receiverChanged?.invoke(true)
+
+                    val samples = FloatArray(BUFFER_SIZE)
+                    while (!Thread.currentThread().isInterrupted) {
+                        receiver.read(samples)
+                        audioTrack.write(samples, 0, samples.size, AudioTrack.WRITE_BLOCKING)
+                    }
+                }
+            }
+
+            audioTrack.release()
+            receiverChanged?.invoke(false)
+            updateNotification(isSenderAlive(), false)
+        })
+
+        receiverThread!!.start()
+
+        if (isForegroundRunning) {
+            updateNotification(isSenderAlive(), true)
+        } else {
+            startForegroundService(isSenderAlive(), true)
+        }
+    }
+
+    fun stopSender() {
+        senderThread?.interrupt()
+    }
+
+    fun stopReceiver() {
+        receiverThread?.interrupt()
+    }
+
+    fun isReceiverAlive(): Boolean {
+        return receiverThread?.isAlive == true
+    }
+
+    fun isSenderAlive(): Boolean {
+        return senderThread?.isAlive == true
+    }
+
+    private fun startForegroundService(sending: Boolean, receiving: Boolean) {
+        isForegroundRunning = true
+        startForeground(NOTIFICATION_ID, buildNotification(sending, receiving))
+    }
+
+    private fun stopForegroundService() {
+        isForegroundRunning = false
+        stopForeground(true)
+    }
+
+    private fun createAudioTrack(): AudioTrack {
+        val audioAttributes = AudioAttributes.Builder().apply {
+            setUsage(AudioAttributes.USAGE_MEDIA)
+            setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+        }.build()
+        val audioFormat = AudioFormat.Builder().apply {
+            setSampleRate(SAMPLE_RATE)
+            setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+            setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+        }.build()
+        val bufferSize = AudioTrack.getMinBufferSize(
+            audioFormat.sampleRate,
+            audioFormat.channelMask,
+            audioFormat.encoding
+        )
+        return AudioTrack.Builder().apply {
+            setAudioAttributes(audioAttributes)
+            setAudioFormat(audioFormat)
+            setBufferSizeInBytes(bufferSize)
+            setTransferMode(AudioTrack.MODE_STREAM)
+            setSessionId(AudioManager.AUDIO_SESSION_ID_GENERATE)
+            setPerformanceMode(AudioTrack.PERFORMANCE_MODE_LOW_LATENCY)
+        }.build()
+    }
+
+    private fun createAudioRecord(): AudioRecord {
+        val bufferSize = AudioRecord.getMinBufferSize(
+            SAMPLE_RATE,
+            AudioFormat.CHANNEL_IN_STEREO,
+            AudioFormat.ENCODING_PCM_FLOAT
+        )
+        return AudioRecord.Builder().apply {
+            setAudioSource(MediaRecorder.AudioSource.DEFAULT)
+            setAudioFormat(AudioFormat.Builder().apply {
+                setChannelMask(AudioFormat.CHANNEL_IN_STEREO)
+                setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+                setSampleRate(SAMPLE_RATE)
+            }.build())
+            setBufferSizeInBytes(bufferSize)
+        }.build()
+    }
+
+    fun setStateChangedListeners(
+        senderChanged: (Boolean) -> Unit,
+        receiverChanged: (Boolean) -> Unit
+    ) {
+        this.receiverChanged = receiverChanged
+        this.senderChanged = senderChanged
+    }
+
+    fun removeListeners() {
+        this.receiverChanged = null
+        this.senderChanged = null
+    }
+}

--- a/app/src/main/res/drawable/ic_stop.xml
+++ b/app/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M6,6h12v12H6z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,4 +19,12 @@
     <string name="allow_mic_ok_message">Thanks! The sender will now start.</string>
 
     <string name="ok">OK</string>
+
+    <string name="notification_channel_name">Sender and Receiver foreground service</string>
+    <string name="notification_receiver_running">Receiver running</string>
+    <string name="notification_sender_running">Sender running</string>
+    <string name="notification_sender_and_receiver_running">Sender and Receiver running</string>
+    <string name="notification_sender_and_receiver_not_running">Neither Sender or Receiver running</string>
+    <string name="notification_title">Roc State</string>
+    <string name="notification_stop_action">Stop</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,5 +26,6 @@
     <string name="notification_sender_and_receiver_running">Sender and Receiver running</string>
     <string name="notification_sender_and_receiver_not_running">Neither Sender or Receiver running</string>
     <string name="notification_title">Roc State</string>
-    <string name="notification_stop_action">Stop</string>
+    <string name="notification_stop_sender_action">Stop Sender</string>
+    <string name="notification_stop_receiver_action">Stop Receiver</string>
 </resources>


### PR DESCRIPTION
This implements #12.

This uses the same sender/receiver thread code from the `MainActivity` with some slight modification. `android:launchMode="singleTop"` is so when tapping the notification body it opens the current activity instead of creating a new 
one.

This doesn't solve #1. I think the receiver thread gets stuck at the native Roc `Receiver.close(long receiverPtr)` function. I'm not sure what causes this.