### PR TITLE
github-workflow: Add deploy steps

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - v*
 
   pull_request:
     branches:
@@ -30,3 +32,15 @@ jobs:
 
       - name: Build
         run: ./gradlew build
+
+      - name: Copy and rename binary
+        if: matrix.os == 'ubuntu-18.04' && startsWith(github.ref, 'refs/tags/')
+        run: cp app/build/outputs/apk/debug/app-debug.apk roc-droid.apk
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: matrix.os == 'ubuntu-18.04' && startsWith(github.ref, 'refs/tags/')
+        with:
+          files: roc-droid.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix #21

Every commit tagged "v*" will create a new release with the .apk as an asset.