### PR TITLE
Allow capturing sound of other apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Android app implementing Roc sender and receiver. **Work in progress!**
 Features:
 
 * **receive** sound from remote Roc-compatible sender and **play** to local audio device
-* **record** sound from local audio device and **send** to remote Roc-compatible receiver
+* **capture** sound from apps or microphone and **send** to remote Roc-compatible receiver
 
 About Roc
 ---------

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
         <service
             android:name=".SenderReceiverService"
             android:exported="false"
+            android:foregroundServiceType="mediaProjection"
             />
 
         <activity

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -72,22 +72,37 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/headerSender" />
 
+    <CheckBox
+        android:id="@+id/usePlaybackCapture"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:checked="false"
+        android:enabled="false"
+        android:minHeight="48dp"
+        android:text="@string/usePlaybackCapture"
+        android:visibility="visible"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/senderExplanation" />
+
     <EditText
         android:id="@+id/receiverIp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
+        android:autofillHints=""
         android:ems="10"
         android:fontFamily="monospace"
         android:hint="@string/receiver_ip"
         android:inputType="number|phone"
-        android:autofillHints=""
+        android:minHeight="48dp"
         android:singleLine="true"
         android:text="@string/default_receiver_ip"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/senderExplanation" />
+        app:layout_constraintTop_toBottomOf="@+id/usePlaybackCapture" />
 
     <Button
         android:id="@+id/startSender"
@@ -101,5 +116,6 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/receiverIp"
         tools:layout_constraintStart_toStartOf="parent" />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,4 +28,5 @@
     <string name="notification_title">Roc State</string>
     <string name="notification_stop_sender_action">Stop Sender</string>
     <string name="notification_stop_receiver_action">Stop Receiver</string>
+    <string name="usePlaybackCapture"><![CDATA[Capture sound of other apps.\nDoes not work with Spotify, requires >= Android 10]]></string>
 </resources>


### PR DESCRIPTION
Allow streaming sound captured using MediaProjection on Android 10 and up by ticking a checkbox
Save ip address between app launches

Also I just noticed this fixes #13 