### PR TITLE
Add version name and code to manifest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install SDK
         uses: malinskiy/action-android/install-sdk@release/0.1.4
@@ -44,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Install SDK
         uses: malinskiy/action-android/install-sdk@release/0.1.4

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,47 @@
+def getVersionName = { ->
+    def manifest = new XmlSlurper().parse(file('src/main/AndroidManifest.xml'))
+    def manifestName = manifest.@'android:versionName'.text()
+
+    def gitStdout = new ByteArrayOutputStream()
+    exec {
+        commandLine 'git', 'describe', '--tags', '--abbrev=0'
+        standardOutput = gitStdout
+    }
+    def gitTag = gitStdout.toString().trim().replaceAll('v', '')
+
+    if (manifestName != gitTag) {
+        throw new GradleException(
+            "Mismatched android:versionName in AndroidManifest.xml and git tag: "+
+                "versionName = $manifestName, "+
+                "gitTag = $gitTag")
+    }
+
+    return manifestName
+}
+
+def getVersionCode = { ->
+    def manifest = new XmlSlurper().parse(file('src/main/AndroidManifest.xml'))
+    def manifestName = manifest.@'android:versionName'.text()
+    def manifestCode = manifest.@'android:versionCode'.text()
+
+    def expectedCode = 0
+    def mult = 1
+    manifestName.tokenize('.').reverse().each {
+        expectedCode += it.toInteger() * mult
+        mult *= 1000
+    }
+
+    if (manifestCode != expectedCode.toString()) {
+        throw new GradleException(
+            "Mismatched android:versionName and android:versionCode in AndroidManifest.xml: "+
+                "versionName = $manifestName, "+
+                "versionCode = $manifestCode, "+
+                "expectedCode = $expectedCode")
+    }
+
+    return manifestCode.toInteger()
+}
+
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
@@ -8,13 +52,13 @@ android {
     ndkVersion project.ndkVersion
 
     defaultConfig {
-        applicationId "org.rocstreaming.rocdroid"
+        applicationId 'org.rocstreaming.rocdroid'
         minSdkVersion project.minSdkVersion.toInteger()
         targetSdkVersion project.targetSdkVersion.toInteger()
-        versionCode 1
-        versionName "1.0"
+        versionName getVersionName()
+        versionCode getVersionCode()
 
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
 
     compileOptions {
@@ -23,7 +67,7 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = '1.8'
     }
 
     lintOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="org.rocstreaming.rocdroid">
+          package="org.rocstreaming.rocdroid"
+          android:versionName="0.0.3"
+          android:versionCode="3">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
Changes:

* AndroidManifest.xml now contains hard-coded versionName and versionCode, as discussed in #24 and needed for #27
* build.gradle loads versionName and versionCode from AndroidManifest.xml
* build.gradle performs to additional checks:
  * versionName in manifest should be same as latest git tag (with `v` removed)
  * versionCode in manifest should be equal to `major*1e6 + minor*1e3 + patch`, e.g. if versionName is `1.2.3`, versionCode should be `1002003`.
* CI is configured to fetch full history with tags

In other words, if we forget to update git tag, version name, or version code, build will fail.

About version code formula:

* with suggested formula, for each tag, we have a unique version code

* having a formula removes the need to check version codes for previous versions; if in a new release, version code passes the formula check, we can be sure that it is larger than all previous version codes

* the formula puts a limitation - each component (major, minor, patch) can't be larger than 999