### PR TITLE
Removed copy toast, replaced it with animation on the copy icon.

### DIFF
--- a/app/src/main/java/org/rocstreaming/rocdroid/component/CopyBlock.kt
+++ b/app/src/main/java/org/rocstreaming/rocdroid/component/CopyBlock.kt
@@ -3,12 +3,14 @@ package org.rocstreaming.rocdroid.component
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.os.Handler
 import android.util.AttributeSet
 import android.util.Log
-import android.view.Gravity
 import android.view.View
+import android.view.animation.Animation
+import android.view.animation.AnimationUtils
+import android.widget.ImageView
 import android.widget.TextView
-import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
 import org.rocstreaming.rocdroid.R
 
@@ -28,7 +30,7 @@ class CopyBlock : ConstraintLayout {
         textBlock = view.findViewById<TextView>(R.id.block_label)
 
         view.findViewById<ConstraintLayout>(R.id.copy_block).setOnClickListener {
-            setClipboard(context, findViewById<TextView>(R.id.block_label).text.toString())
+            setClipboard(context, findViewById<TextView>(R.id.block_label).text.toString(), it.findViewById<ImageView>(R.id.copy_icon))
         }
     }
 
@@ -38,7 +40,7 @@ class CopyBlock : ConstraintLayout {
         textBlock?.text = text
     }
 
-    fun setClipboard(context: Context, text: String) {
+    fun setClipboard(context: Context, text: String, icon: ImageView) {
         Log.d(LOG_TAG, String.format("Copying Text: %s", text))
 
         val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
@@ -46,8 +48,26 @@ class CopyBlock : ConstraintLayout {
         val clipData = ClipData.newPlainText("text", text)
         clipboardManager.setPrimaryClip(clipData)
 
-        val myToast = Toast.makeText(context, "Copied!", Toast.LENGTH_SHORT)
+        animateImageChange(context, icon, R.drawable.ic_done)
+        Handler().postDelayed({
+            animateImageChange(context, icon, R.drawable.ic_copy)
+        }, 1250)
+        /*val myToast = Toast.makeText(context, "Copied!", Toast.LENGTH_SHORT)
         myToast.setGravity(Gravity.CENTER, 0, 200)
-        myToast.show()
+        myToast.show()*/
+    }
+
+    private fun animateImageChange(c: Context?, icon: ImageView, image: Int) {
+        val animOut: Animation = AnimationUtils.loadAnimation(c, android.R.anim.fade_out)
+        val animIn: Animation = AnimationUtils.loadAnimation(c, android.R.anim.fade_in)
+        animOut.setAnimationListener(object : Animation.AnimationListener {
+            override fun onAnimationStart(animation: Animation?) {}
+            override fun onAnimationRepeat(animation: Animation?) {}
+            override fun onAnimationEnd(animation: Animation?) {
+                icon.setImageResource(image)
+                icon.startAnimation(animIn)
+            }
+        })
+        icon.startAnimation(animOut)
     }
 }

--- a/app/src/main/java/org/rocstreaming/rocdroid/component/CopyBlock.kt
+++ b/app/src/main/java/org/rocstreaming/rocdroid/component/CopyBlock.kt
@@ -26,11 +26,10 @@ class CopyBlock : ConstraintLayout {
         Log.d(LOG_TAG, "Init Copy Block")
 
         val view: View = inflate(context, R.layout.copy_block_component, this)
-
         textBlock = view.findViewById<TextView>(R.id.block_label)
 
         view.findViewById<ConstraintLayout>(R.id.copy_block).setOnClickListener {
-            setClipboard(context, findViewById<TextView>(R.id.block_label).text.toString(), it.findViewById<ImageView>(R.id.copy_icon))
+            setClipboard(context, textBlock.text, it.findViewById(R.id.copy_icon))
         }
     }
 
@@ -40,7 +39,7 @@ class CopyBlock : ConstraintLayout {
         textBlock?.text = text
     }
 
-    fun setClipboard(context: Context, text: String, icon: ImageView) {
+    private fun setClipboard(context: Context, text: CharSequence, icon: ImageView) {
         Log.d(LOG_TAG, String.format("Copying Text: %s", text))
 
         val clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
@@ -51,13 +50,12 @@ class CopyBlock : ConstraintLayout {
         animateImageChange(context, icon, R.drawable.ic_done)
         Handler().postDelayed({
             animateImageChange(context, icon, R.drawable.ic_copy)
-        }, 1250)
-        /*val myToast = Toast.makeText(context, "Copied!", Toast.LENGTH_SHORT)
-        myToast.setGravity(Gravity.CENTER, 0, 200)
-        myToast.show()*/
+        }, 1000)
     }
 
     private fun animateImageChange(c: Context?, icon: ImageView, image: Int) {
+        Log.d(LOG_TAG, String.format("Changing image in Copy Block"))
+
         val animOut: Animation = AnimationUtils.loadAnimation(c, android.R.anim.fade_out)
         val animIn: Animation = AnimationUtils.loadAnimation(c, android.R.anim.fade_in)
         animOut.setAnimationListener(object : Animation.AnimationListener {

--- a/app/src/main/res/drawable/ic_done.xml
+++ b/app/src/main/res/drawable/ic_done.xml
@@ -1,0 +1,23 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="22.59dp"
+    android:height="27.11dp"
+    android:viewportWidth="22.59"
+    android:viewportHeight="27.11">
+    <path
+        android:pathData="M3.27,5.85L14.31,5.85A2.27,2.27 0,0 1,16.58 8.12L16.58,23.85A2.27,2.27 0,0 1,14.31 26.12L3.27,26.12A2.27,2.27 0,0 1,1 23.85L1,8.12A2.27,2.27 0,0 1,3.27 5.85z"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="@color/colorGreen"/>
+    <path
+        android:pathData="M6,3.27A2.27,2.27 0,0 1,8.29 1L19.29,1a2.27,2.27 0,0 1,2.26 2.27L21.55,19A2.27,2.27 0,0 1,19.29 21.27"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="@color/colorGreen"
+        android:strokeLineCap="round"/>
+    <path
+        android:pathData="M9,16.2l-3.5,-3.5c-0.39,-0.39 -1.01,-0.39 -1.4,0 -0.39,0.39 -0.39,1.01 0,1.4l4.19,4.19c0.39,0.39 1.02,0.39 1.41,0L20.3,7.7c0.39,-0.39 0.39,-1.01 0,-1.4 -0.39,-0.39 -1.01,-0.39 -1.4,0L9,16.2z"
+        android:strokeWidth="2"
+        android:fillColor="#00000000"
+        android:strokeColor="@color/colorGreen"
+        android:strokeLineCap="round"/>
+</vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="white">#FFFFFF</color>
     <color name="colorBlack">#0D1821</color>
     <color name="colorLight">#BFD0DE</color>
+    <color name="colorGreen">#59A174</color>
 </resources>


### PR DESCRIPTION
Change resolving #50 by removing toast and replacing it with an animation on the copy icon to show that the field has been copied.

Possible alternative could be checking android version to see if it's 12 or higher and displaying the toast depending on that. Decided against it because the "copied to clipboard" OS Toast can be disabled in settings by user.
App cannot disable OS Toast due to it being OS level and automatic.