### PR TITLE
Sign release APK

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,10 +31,12 @@ jobs:
         uses: malinskiy/action-android/install-sdk@release/0.1.4
 
       - name: Install NDK
-        run: sdkmanager --install "ndk;$(grep ndkVersion app/gradle.properties | cut -d= -f2)"
+        run: |
+          sdkmanager --install "ndk;$(grep ndkVersion app/gradle.properties | cut -d= -f2)"
 
       - name: Build
-        run: ./gradlew build
+        run: |
+          ./gradlew build
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -51,25 +53,26 @@ jobs:
         uses: malinskiy/action-android/install-sdk@release/0.1.4
 
       - name: Install NDK
-        run: sdkmanager --install "ndk;$(grep ndkVersion app/gradle.properties | cut -d= -f2)"
-
-      - name: Get release info
-        id: get-info
         run: |
-          echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          sdkmanager --install "ndk;$(grep ndkVersion app/gradle.properties | cut -d= -f2)"
 
       - name: Check version
-        run: ./gradlew checkVersion
+        run: |
+          ./gradlew checkVersion
 
-      - name: Build
-        run: ./gradlew build
-
-      - name: Copy and rename binary
-        run: cp app/build/outputs/apk/debug/app-debug.apk roc-droid-${{ env.VERSION }}.apk
+      - name: Build APK
+        env:
+          SIGNING_STORE_FILE: roc-droid.jks
+          SIGNING_STORE_PASSWORD: ${{ secrets.SIGNING_STORE_PASSWORD }}
+          SIGNING_KEY_ALIAS: ${{ secrets.SIGNING_KEY_ALIAS }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
+        run: |
+          echo "${{ secrets.SIGNING_STORE_BASE64 }}" | base64 -di > app/${{ env.SIGNING_STORE_FILE }}
+          ./gradlew assembleRelease
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          files: roc-droid-${{ env.VERSION }}.apk
+          files: app/build/outputs/apk/release/roc-droid-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .gradle
+*.jks
 /local.properties
 /.idea/*
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -87,6 +87,38 @@ To check consistency of version name and code:
 ./gradlew checkVersion
 ```
 
+Signing
+-------
+
+Keystore with certificates was generated using this command:
+
+```
+keytool -genkey -v -keystore roc-droid.jks -alias apk -keyalg RSA -keysize 2048 -validity 10000
+```
+
+Then it was encoded to base64:
+
+```
+base64 roc-droid.jks
+```
+
+Then the following secrets were added to the repo:
+
+* `SIGNING_STORE_BASE64` - base64-encoded keystore (`roc-droid.jks`)
+* `SIGNING_STORE_PASSWORD` - keystore password
+* `SIGNING_KEY_ALIAS` - key alias (`apk`)
+* `SIGNING_KEY_PASSWORD` - key password (same as keystore password)
+
+GitHub actions decode `SIGNING_STORE_BASE64` into a temporary `.jks` file and set `SIGNING_*` environment variables with the name of the file and credentials.
+
+Then the following command is run:
+
+```
+./gradlew assembleRelease
+```
+
+It reads credentials from the environment variables and signs release APK using them.
+
 Authors
 -------
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -64,15 +64,24 @@ apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion project.compileSdkVersion.toInteger()
+
     buildToolsVersion project.buildToolsVersion
     ndkVersion project.ndkVersion
 
     defaultConfig {
         applicationId 'org.rocstreaming.rocdroid'
+
         minSdkVersion project.minSdkVersion.toInteger()
         targetSdkVersion project.targetSdkVersion.toInteger()
+
         versionName getVersionName()
         versionCode getVersionCode()
+    }
+
+    applicationVariants.all { variant ->
+        variant.outputs.all {
+            outputFileName = "roc-droid-${versionName}.apk"
+        }
     }
 
     compileOptions {
@@ -88,10 +97,25 @@ android {
         abortOnError false
     }
 
+    signingConfigs {
+        release {
+            if (System.getenv("SIGNING_STORE_FILE") != null) {
+                storeFile file(System.getenv("SIGNING_STORE_FILE"))
+                storePassword System.getenv("SIGNING_STORE_PASSWORD")
+                keyAlias System.getenv("SIGNING_KEY_ALIAS")
+                keyPassword System.getenv("SIGNING_KEY_PASSWORD")
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt')
+
+            if (System.getenv("SIGNING_STORE_FILE") != null) {
+                signingConfig signingConfigs.release
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #39.

Changes:

- Add signingConfig to gradle (enabled if corresponding env vars are set)
- Export signing secrets when building release APK on CI
- Document process in README

Secrets are already added to the repo.