### PR TITLE
Refine event handling in android backend (#98)

### DIFF
--- a/lib/src/agent.dart
+++ b/lib/src/agent.dart
@@ -2,4 +2,6 @@
 export 'agent/android_backend.dart';
 export 'agent/android_bridge.g.dart';
 export 'agent/backend.dart';
+export 'agent/failure_event.dart';
 export 'agent/noop_backend.dart';
+export 'agent/state_event.dart';

--- a/lib/src/agent/android_backend.dart
+++ b/lib/src/agent/android_backend.dart
@@ -3,6 +3,8 @@ import 'package:logger/logger.dart';
 
 import 'android_bridge.g.dart';
 import 'backend.dart';
+import 'failure_event.dart';
+import 'state_event.dart';
 
 /// Android-specific implementation of Backend interface.
 ///
@@ -29,10 +31,10 @@ class AndroidBackend implements Backend, AndroidListener {
   bool senderIsAlive = false;
 
   @override
-  final Event<Value<String>> stateChangeEvent = Event();
+  final Event<Value<StateEvent>> stateChangeEvent = Event("stateChangeEvent");
 
   @override
-  final Event<Value<String>> failureEvent = Event();
+  final Event<Value<FailureEvent>> failureEvent = Event("failureEvent");
 
   /// Inherited from Backend interface.
   /// Invoked from model.
@@ -190,7 +192,7 @@ class AndroidBackend implements Backend, AndroidListener {
   @override
   void onEvent(AndroidServiceEvent eventCode) async {
     _logger.d("Registered event: $eventCode");
-    await refreshState(eventCode.name);
+    await refreshState();
   }
 
   /// Inherited from AndroidListener interface.
@@ -198,14 +200,22 @@ class AndroidBackend implements Backend, AndroidListener {
   @override
   void onError(AndroidServiceError errorCode) async {
     _logger.d("Registered event: $errorCode");
-    await refreshState(errorCode.name);
+
+    await refreshState();
+
+    switch (errorCode) {
+      case AndroidServiceError.audioRecordFailed:
+      case AndroidServiceError.audioTrackFailed:
+        failureEvent.broadcast(Value<FailureEvent>(FailureEvent.deviceError));
+
+      case AndroidServiceError.senderConnectFailed:
+      case AndroidServiceError.receiverBindFailed:
+        failureEvent.broadcast(Value<FailureEvent>(FailureEvent.networkError));
+    }
   }
 
   /// Async method used in all Android service event types.
-  Future<void> refreshState([String? eventCode]) async {
-    final broadcastValue =
-        eventCode == null ? "Register state change" : eventCode;
-
+  Future<void> refreshState() async {
     final newReceiverIsAlive = await _connector.isReceiverAlive();
     if (receiverIsAlive != newReceiverIsAlive) {
       _logger.d(
@@ -214,7 +224,8 @@ class AndroidBackend implements Backend, AndroidListener {
 
       // Whenever receiver state changes, no matter how we've found out (from kotlin
       // event of from finally block), we notify subscribers
-      stateChangeEvent.broadcast(Value(broadcastValue));
+      stateChangeEvent
+          .broadcast(Value<StateEvent>(StateEvent.receiverStateChanged));
     }
 
     final newSenderIsAlive = await _connector.isSenderAlive();
@@ -225,7 +236,8 @@ class AndroidBackend implements Backend, AndroidListener {
 
       // Whenever sender state changes, no matter how we've found out (from kotlin
       // event of from finally block), we notify subscribers
-      stateChangeEvent.broadcast(Value(broadcastValue));
+      stateChangeEvent
+          .broadcast(Value<StateEvent>(StateEvent.senderStateChanged));
     }
   }
 }

--- a/lib/src/agent/backend.dart
+++ b/lib/src/agent/backend.dart
@@ -1,6 +1,8 @@
 import 'package:event/event.dart';
 
 import 'android_bridge.g.dart';
+import 'failure_event.dart';
+import 'state_event.dart';
 
 // This is intended to be platform-independent interface for streaming backend,
 // implemented differently on mobile and desktop.
@@ -24,8 +26,12 @@ import 'android_bridge.g.dart';
 abstract class Backend {
   abstract bool receiverIsAlive;
   abstract bool senderIsAlive;
-  abstract final Event<Value<String>> stateChangeEvent;
-  abstract final Event<Value<String>> failureEvent;
+
+  /// Emitted when receiverIsAlive or senderIsAlive changes its value.
+  abstract final Event<Value<StateEvent>> stateChangeEvent;
+
+  /// Emitted when sender or receiver fails in background.
+  abstract final Event<Value<FailureEvent>> failureEvent;
 
   Future<List<String>> getLocalAddresses();
 

--- a/lib/src/agent/failure_event.dart
+++ b/lib/src/agent/failure_event.dart
@@ -1,0 +1,5 @@
+/// Event codes for failure event.
+enum FailureEvent {
+  deviceError,
+  networkError,
+}

--- a/lib/src/agent/noop_backend.dart
+++ b/lib/src/agent/noop_backend.dart
@@ -2,6 +2,8 @@ import 'package:event/event.dart';
 
 import 'android_bridge.g.dart';
 import 'backend.dart';
+import 'failure_event.dart';
+import 'state_event.dart';
 
 class NoopBackend implements Backend {
   @override
@@ -11,10 +13,10 @@ class NoopBackend implements Backend {
   bool senderIsAlive = false;
 
   @override
-  final Event<Value<String>> stateChangeEvent = Event("stateChangeEvent");
+  final Event<Value<StateEvent>> stateChangeEvent = Event("stateChangeEvent");
 
   @override
-  final Event<Value<String>> failureEvent = Event("failureEvent");
+  final Event<Value<FailureEvent>> failureEvent = Event("failureEvent");
 
   @override
   Future<List<String>> getLocalAddresses() async {

--- a/lib/src/agent/state_event.dart
+++ b/lib/src/agent/state_event.dart
@@ -1,0 +1,5 @@
+/// Event codes for state change events.
+enum StateEvent {
+  senderStateChanged,
+  receiverStateChanged,
+}

--- a/lib/src/model/model_root.dart
+++ b/lib/src/model/model_root.dart
@@ -12,7 +12,7 @@ class ModelRoot {
   late final Logger logger;
 
   /// Used to notify if the backend service has registered an error event.
-  final Event<Value<String>> failureEvent = Event("failureEvent");
+  final Event<Value<FailureEvent>> failureEvent = Event("failureEvent");
 
   ModelRoot(Logger logger, Backend backend) {
     this.receiver = Receiver(logger, backend);

--- a/lib/src/model/receiver.dart
+++ b/lib/src/model/receiver.dart
@@ -49,7 +49,7 @@ abstract class _Receiver with Store {
     // Subscribe to backend state change event.
     _backend.stateChangeEvent.subscribe(
       (args) async {
-        _isStarted = await backend.receiverIsAlive;
+        _isStarted = backend.receiverIsAlive;
       },
     );
     _setDefultValues();

--- a/lib/src/model/sender.dart
+++ b/lib/src/model/sender.dart
@@ -55,7 +55,7 @@ abstract class _Sender with Store {
     // Subscribe to backend state change event.
     _backend.stateChangeEvent.subscribe(
       (args) async {
-        _isStarted = await backend.senderIsAlive;
+        _isStarted = backend.senderIsAlive;
       },
     );
     _setDefultValues();

--- a/lib/src/ui/localization/app_en.arb
+++ b/lib/src/ui/localization/app_en.arb
@@ -53,5 +53,9 @@
 
     "enterIp": "Enter IP address",
 
+    "deviceError": "Audio device error",
+
+    "networkError": "Network error",
+
     "appVersion": "v0.2.1"
 }

--- a/lib/src/ui/main_screen.dart
+++ b/lib/src/ui/main_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 
+import '../agent.dart';
 import '../model/model_root.dart';
 import 'components/roc_snackbar.dart';
 import 'fragments/roc_bottom_navigation_bar.dart';
@@ -45,8 +46,11 @@ class _MainScreenState extends State<MainScreen> {
         ] {
     // Subscribe to model failure event (coming from backend failure event).
     _modelRoot.failureEvent.subscribe((args) {
-      var message = args.value;
-      RocSnackbar.showMessage(context: context, message: 'Error: $message');
+      var message = switch (args.value) {
+        FailureEvent.deviceError => AppLocalizations.of(context)!.deviceError,
+        FailureEvent.networkError => AppLocalizations.of(context)!.networkError,
+      };
+      RocSnackbar.showMessage(context: context, message: message);
     });
   }
 


### PR DESCRIPTION
- Add 2 new enums: agent.StateEvent and agent.FailureEvent.
  We'll use them instead of string code when emitting events
  from agent to model, to ensure that model won't have an
  implicit dependency on some magic strings.

- refreshState() generates StateEvent. No matter what even we got
  from kotlin, we always check actual state we have right now and
  generate event according to that state. This way we can be sure
  that events received by model will be consistent with the state
  that it observes when calling receiverIsAlive/senderIsAlive.

- onError() translates error codes from kotlin to higher-level
  failure event codes. Model translates these error codes to
  localized error messages. UI shows these messages.