### PR TITLE
Make tests easier to run from CLI (#94)

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -78,7 +78,7 @@ def task_test():
     """run tests"""
     return {
         'basename': 'test',
-        'actions': ['flutter test -j1 -r expanded'],
+        'actions': ['flutter test -j1 -r github'],
         'title': title_with_actions,
     }
 

--- a/lib/src/model.dart
+++ b/lib/src/model.dart
@@ -1,2 +1,5 @@
 /// Model export definition.
+export 'model/capture_source_type.dart';
 export 'model/model_root.dart';
+export 'model/receiver.dart';
+export 'model/sender.dart';

--- a/script/android_logcat.py
+++ b/script/android_logcat.py
@@ -10,6 +10,7 @@ import signal
 import subprocess
 
 LEVEL_COLORS = {
+    'F': Back.RED,
     'E': Back.RED,
     'W': Back.YELLOW,
     'I': Back.GREEN,

--- a/test/model/model_root_test.dart
+++ b/test/model/model_root_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
-import 'package:roc_droid/src/model.dart';
+
+import '../test_helpers.dart';
 
 // Model root class unit tests.
 void main() {
@@ -10,7 +9,7 @@ void main() {
   test(
       'The Receiver, Sender and Logger must be created correctly during the creation of the ModelRoot instance.',
       () {
-    var modelRoot = ModelRoot(Logger(), NoopBackend());
+    var modelRoot = testModelRoot();
     expect(modelRoot.receiver, isNotNull);
     expect(modelRoot.sender, isNotNull);
     expect(modelRoot.logger, isNotNull);

--- a/test/model/receiver_test.dart
+++ b/test/model/receiver_test.dart
@@ -1,16 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
-import 'package:roc_droid/src/model/receiver.dart';
+
+import '../test_helpers.dart';
 
 // Receiver class unit tests.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  Receiver makeReceiver() => Receiver(Logger(), NoopBackend());
-
   test('Check the receivers initial values and getters.', () async {
-    final receiver = makeReceiver();
+    final receiver = testReceiver();
     expect(receiver.isStarted, false);
     expect(receiver.receiverIPs, List.empty());
     expect(receiver.sourcePort, -1);
@@ -18,14 +15,14 @@ void main() {
   });
 
   test('Check the source port setter method.', () async {
-    final receiver = makeReceiver();
+    final receiver = testReceiver();
     final testValue = 123;
     receiver.setSourcePort(testValue);
     expect(receiver.sourcePort, testValue);
   });
 
   test('Check the repair port setter method.', () async {
-    final receiver = makeReceiver();
+    final receiver = testReceiver();
     final testValue = 123;
     receiver.setRepairPort(testValue);
     expect(receiver.repairPort, testValue);

--- a/test/model/sender_test.dart
+++ b/test/model/sender_test.dart
@@ -1,17 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
-import 'package:roc_droid/src/model/capture_source_type.dart';
-import 'package:roc_droid/src/model/sender.dart';
+import 'package:roc_droid/src/model.dart';
+
+import '../test_helpers.dart';
 
 // Receiver class unit tests.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  Sender makeSender() => Sender(Logger(), NoopBackend());
-
   test('Check the senders initial values and getters.', () async {
-    final sender = makeSender();
+    final sender = testSender();
     expect(sender.isStarted, false);
     expect(sender.sourcePort, 10001);
     expect(sender.repairPort, 10002);
@@ -21,35 +18,35 @@ void main() {
   });
 
   test('Check the senders stop method when sender is not active.', () async {
-    final sender = makeSender();
+    final sender = testSender();
     expect(sender.isStarted, false);
     await sender.requestAsyncStop();
     expect(sender.isStarted, false);
   });
 
   test('Check the source port setter method.', () async {
-    final sender = makeSender();
+    final sender = testSender();
     final testValue = 123;
     sender.setSourcePort(testValue);
     expect(sender.sourcePort, testValue);
   });
 
   test('Check the repair port setter method.', () async {
-    final sender = makeSender();
+    final sender = testSender();
     final testValue = 123;
     sender.setRepairPort(testValue);
     expect(sender.repairPort, testValue);
   });
 
   test('Check the receiver IP setter method.', () async {
-    final sender = makeSender();
+    final sender = testSender();
     final testValue = 'testIP';
     sender.setReceiverIP(testValue);
     expect(sender.receiverIP, testValue);
   });
 
   test('Check the capture source setter method.', () async {
-    final sender = makeSender();
+    final sender = testSender();
     final testValue = CaptureSourceType.microphone;
     sender.setCaptureSource(testValue);
     expect(sender.captureSource, testValue);

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -1,0 +1,18 @@
+import 'package:logger/logger.dart';
+import 'package:roc_droid/src/agent.dart';
+import 'package:roc_droid/src/model.dart';
+
+ModelRoot testModelRoot() => ModelRoot(
+      Logger(printer: SimplePrinter()),
+      NoopBackend(),
+    );
+
+Receiver testReceiver() => Receiver(
+      Logger(printer: SimplePrinter()),
+      NoopBackend(),
+    );
+
+Sender testSender() => Sender(
+      Logger(printer: SimplePrinter()),
+      NoopBackend(),
+    );

--- a/test/ui/app_root_test.dart
+++ b/test/ui/app_root_test.dart
@@ -1,15 +1,14 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
-import 'package:roc_droid/src/model.dart';
 import 'package:roc_droid/src/ui.dart';
 import 'package:roc_droid/src/ui/main_screen.dart';
+
+import '../test_helpers.dart';
 
 // App root class widget tests.
 void main() {
   testWidgets('The AppRoot widget is built correctly.', (tester) async {
     // Action
-    await tester.pumpWidget(AppRoot(ModelRoot(Logger(), NoopBackend())));
+    await tester.pumpWidget(AppRoot(testModelRoot()));
 
     // Find required widgets
     final mainScreenWidget = find.byType(MainScreen);

--- a/test/ui/main_screen_test.dart
+++ b/test/ui/main_screen_test.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
-import 'package:roc_droid/src/model.dart';
 import 'package:roc_droid/src/ui.dart';
 import 'package:roc_droid/src/ui/fragments/roc_bottom_navigation_bar.dart';
 import 'package:roc_droid/src/ui/main_screen.dart';
 import 'package:roc_droid/src/ui/pages/receiver_page.dart';
 
+import '../test_helpers.dart';
+
 // Main screen class widget tests.
 void main() {
   testWidgets('The MainScreen widget is built correctly.', (tester) async {
     // Action
-    await tester.pumpWidget(AppRoot(ModelRoot(Logger(), NoopBackend())));
+    await tester.pumpWidget(AppRoot(testModelRoot()));
 
     // Find required widgets
     final mainScreen = find.byType(MainScreen);

--- a/test/ui/pages/about_page_test.dart
+++ b/test/ui/pages/about_page_test.dart
@@ -1,18 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
-import 'package:roc_droid/src/model.dart';
 import 'package:roc_droid/src/ui.dart';
 import 'package:roc_droid/src/ui/components/roc_scroll_view.dart';
 import 'package:roc_droid/src/ui/pages/about_page.dart';
 import 'package:roc_droid/src/ui/utils/roc_keys.dart';
 
+import '../../test_helpers.dart';
+
 // Side pane class widget tests.
 void main() {
   testWidgets('The about page widget is built correctly.', (tester) async {
     // Action
-    await tester.pumpWidget(AppRoot(ModelRoot(Logger(), NoopBackend())));
+    await tester.pumpWidget(AppRoot(testModelRoot()));
     await tester.tap(find.byKey(RocKeys.sidePaneKey));
     await tester.pumpAndSettle();
 

--- a/test/ui/pages/receiver_page_test.dart
+++ b/test/ui/pages/receiver_page_test.dart
@@ -1,7 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
-import 'package:roc_droid/src/model.dart';
 import 'package:roc_droid/src/ui.dart';
 import 'package:roc_droid/src/ui/components/roc_button.dart';
 import 'package:roc_droid/src/ui/components/roc_chip.dart';
@@ -9,11 +6,13 @@ import 'package:roc_droid/src/ui/components/roc_page_view.dart';
 import 'package:roc_droid/src/ui/components/roc_text_row.dart';
 import 'package:roc_droid/src/ui/pages/receiver_page.dart';
 
+import '../../test_helpers.dart';
+
 // Receiver page class widget tests.
 void main() {
   testWidgets('The ReceiverPage widget is built correctly.', (tester) async {
     // Action
-    await tester.pumpWidget(AppRoot(ModelRoot(Logger(), NoopBackend())));
+    await tester.pumpWidget(AppRoot(testModelRoot()));
 
     // Find required widgets
     final receiverPage = find.byType(ReceiverPage);

--- a/test/ui/pages/sender_page_test.dart
+++ b/test/ui/pages/sender_page_test.dart
@@ -1,8 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:logger/logger.dart';
-import 'package:roc_droid/src/agent.dart';
 import 'package:roc_droid/src/model.dart';
-import 'package:roc_droid/src/model/capture_source_type.dart';
 import 'package:roc_droid/src/ui.dart';
 import 'package:roc_droid/src/ui/components/roc_button.dart';
 import 'package:roc_droid/src/ui/components/roc_chip.dart';
@@ -12,11 +9,13 @@ import 'package:roc_droid/src/ui/components/roc_text_row.dart';
 import 'package:roc_droid/src/ui/pages/sender_page.dart';
 import 'package:roc_droid/src/ui/utils/roc_keys.dart';
 
+import '../../test_helpers.dart';
+
 // Sender page class widget tests.
 void main() {
   testWidgets('The SenderPage widget is built correctly.', (tester) async {
     // Action
-    await tester.pumpWidget(AppRoot(ModelRoot(Logger(), NoopBackend())));
+    await tester.pumpWidget(AppRoot(testModelRoot()));
     await tester.tap(find.byKey(RocKeys.senderPageKey));
     await tester.pumpAndSettle();
 


### PR DESCRIPTION
- Extract test_helpers.dart with helper functions used in all
  tests for creating test instances of model root, sender,
  and receiver.

- When creating test instances, use SimplePrinter instead of default.
  In other words, we continue to use default printer in the app,
  but we use simple compact printer in tests.

- In "doit test", use "github" reporter instead of "expanded".
  It gives cleaner output when mixed with logs from tests.

- Fix crash in android_logcat.py (add handler for 'F' level).