### PR TITLE
More linter rules (#94)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,47 +1,70 @@
 analyzer:
-  exclude:
-    # @TODO - check this
-    - 'build/**'
-    - '**/*.g.dart'
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
   errors:
     todo: ignore
+  exclude:
+    - 'build/**'
+    - '**/*.g.dart'
 
 linter:
   rules:
     # based on effective_dart rules
     # https://github.com/tenhobi/effective_dart/blob/master/lib/analysis_options.1.2.0.yaml
-    # https://dart-lang.github.io/linter/lints/
+    # https://dart.dev/tools/linter-rules
     - annotate_overrides
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
     - avoid_relative_lib_imports
     - avoid_return_types_on_setters
     - avoid_returning_null
+    - avoid_returning_null_for_void
+    - await_only_futures
     - camel_case_extensions
     - camel_case_types
+    - collection_methods_unrelated_type
     - constant_identifier_names
+    - control_flow_in_finally
     - curly_braces_in_flow_control_structures
+    - depend_on_referenced_packages
     - directives_ordering
+    - discarded_futures
     - empty_constructor_bodies
+    - exhaustive_cases
     - file_names
     - hash_and_equals
     - implementation_imports
     - library_names
     - library_prefixes
+    - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
+    - no_wildcard_variable_uses
     - non_constant_identifier_names
+    - null_check_on_nullable_type_parameter
+    - null_closures
+    - package_names
     - prefer_equal_for_default_values
     - prefer_generic_function_type_aliases
     - prefer_mixin
     - prefer_relative_imports
+    - recursive_getters
     - slash_for_doc_comments
     - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures
+    - unintended_html_in_doc_comment
     - unnecessary_const
+    - unnecessary_late
     - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_to_list_in_spreads
+    - unrelated_type_equality_checks
+    - use_function_type_syntax_for_parameters
     - use_rethrow_when_possible
+    - use_string_in_part_of_directives
+    - valid_regexps
+    - void_checks

--- a/dodo.py
+++ b/dodo.py
@@ -116,6 +116,7 @@ def task_build_apk():
         'basename': 'build:apk',
         'actions': [f'flutter build apk --{VARIANT}'],
         'title': title_with_actions,
+        'task_dep': ['lint:dart', 'lint:kotlin'],
     }
 
 # doit wipe

--- a/lib/src/model/receiver.dart
+++ b/lib/src/model/receiver.dart
@@ -49,9 +49,11 @@ abstract class _Receiver with Store {
     // Subscribe to backend state change event.
     _backend.stateChangeEvent.subscribe(
       (args) async {
-        _isStarted = await backend.receiverIsAlive;
+        _isStarted = backend.receiverIsAlive;
       },
     );
+    // TODO(gh-98): async constructor
+    // ignore: discarded_futures
     _setDefultValues();
   }
 

--- a/lib/src/model/sender.dart
+++ b/lib/src/model/sender.dart
@@ -55,7 +55,7 @@ abstract class _Sender with Store {
     // Subscribe to backend state change event.
     _backend.stateChangeEvent.subscribe(
       (args) async {
-        _isStarted = await backend.senderIsAlive;
+        _isStarted = backend.senderIsAlive;
       },
     );
     _setDefultValues();

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <flutter_localization/flutter_localization_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) flutter_localization_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterLocalizationPlugin");
-  flutter_localization_plugin_register_with_registrar(flutter_localization_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  flutter_localization
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,10 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import flutter_localization
-import shared_preferences_foundation
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  FlutterLocalizationPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalizationPlugin"))
-  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_localization: ^0.3.1
+  flutter_localizations:
+    sdk: flutter
   intl: ^0.19.0
   logger: ^2.4.0
   mobx: ^2.3.3+2

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <flutter_localization/flutter_localization_plugin_c_api.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  FlutterLocalizationPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FlutterLocalizationPluginCApi"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,7 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  flutter_localization
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Some are cosmetic, however a few are important:

1. await_only_futures - detect use of `await` where it has no effect
2. discarded_futures - detect missing `await` when calling `async` func
3. depend_on_referenced_packages - detect imported packages missing
   from pubspec

These 3 rules found a few bugs:

- unneeded await for xxxIsAlive (this commit removes it)

- missing await for _setDefultValues (this commit temporary
  adds `ignore` comment, this should be fixed separately)

- invalid dependency: in pubspec we had `flutter_localization`,
  but in code we used `flutter_localizations` (note the "s"),
  they are different packages
  (this commit fixes pubspec)