### PR TITLE
Minor refactoring (#98)

### DIFF
--- a/lib/src/agent/android_backend.dart
+++ b/lib/src/agent/android_backend.dart
@@ -16,6 +16,9 @@ class AndroidBackend implements Backend, AndroidListener {
   final Logger _logger;
   final AndroidConnector _connector;
 
+  bool _receiverIsAlive = false;
+  bool _senderIsAlive = false;
+
   AndroidBackend(Logger logger)
       : _logger = logger,
         _connector = AndroidConnector() {
@@ -25,10 +28,10 @@ class AndroidBackend implements Backend, AndroidListener {
   }
 
   @override
-  bool receiverIsAlive = false;
+  bool get receiverIsAlive => _receiverIsAlive;
 
   @override
-  bool senderIsAlive = false;
+  bool get senderIsAlive => _senderIsAlive;
 
   @override
   final Event<Value<StateEvent>> stateChangeEvent = Event("stateChangeEvent");
@@ -214,10 +217,10 @@ class AndroidBackend implements Backend, AndroidListener {
   /// Async method used in all Android service event types.
   Future<void> refreshState() async {
     final newReceiverIsAlive = await _connector.isReceiverAlive();
-    if (receiverIsAlive != newReceiverIsAlive) {
+    if (_receiverIsAlive != newReceiverIsAlive) {
       _logger.d(
-          "Detected receiver state change from $receiverIsAlive to $newReceiverIsAlive");
-      receiverIsAlive = newReceiverIsAlive;
+          "Detected receiver state change from $_receiverIsAlive to $newReceiverIsAlive");
+      _receiverIsAlive = newReceiverIsAlive;
 
       // Whenever receiver state changes, no matter how we've found out (from kotlin
       // event of from finally block), we notify subscribers
@@ -226,10 +229,10 @@ class AndroidBackend implements Backend, AndroidListener {
     }
 
     final newSenderIsAlive = await _connector.isSenderAlive();
-    if (senderIsAlive != newSenderIsAlive) {
+    if (_senderIsAlive != newSenderIsAlive) {
       _logger.d(
-          "Detected sender state change from $senderIsAlive to $newSenderIsAlive");
-      senderIsAlive = newSenderIsAlive;
+          "Detected sender state change from $_senderIsAlive to $newSenderIsAlive");
+      _senderIsAlive = newSenderIsAlive;
 
       // Whenever sender state changes, no matter how we've found out (from kotlin
       // event of from finally block), we notify subscribers

--- a/lib/src/model/model_root.dart
+++ b/lib/src/model/model_root.dart
@@ -8,17 +8,16 @@ import 'sender.dart';
 
 /// Root class of the main model.
 class ModelRoot {
-  late final Receiver receiver;
-  late final Sender sender;
-  late final PackageInfo packageInfo;
-  late final Logger logger;
+  final Receiver receiver;
+  final Sender sender;
+  final PackageInfo packageInfo;
+  final Logger logger;
 
   /// Used to notify if the backend service has registered an error event.
   final Event<Value<FailureEvent>> failureEvent = Event("failureEvent");
 
-  ModelRoot._create(Logger logger, Backend backend) {
-    this.logger = logger;
-
+  ModelRoot._create(Backend backend, this.receiver, this.sender,
+      this.packageInfo, this.logger) {
     // Broadcast failure event only on backend failure events
     backend.failureEvent.subscribe((args) {
       failureEvent.broadcast(args);
@@ -28,10 +27,8 @@ class ModelRoot {
   /// Public ModelRoot factory
   static Future<ModelRoot> create(
       Logger logger, Backend backend, PackageInfo packageInfo) async {
-    var modelRoot = ModelRoot._create(logger, backend);
-    modelRoot.receiver = await ReceiverFactory.create(logger, backend);
-    modelRoot.sender = await SenderFactory.create(logger, backend);
-    modelRoot.packageInfo = packageInfo;
-    return modelRoot;
+    final receiver = await Receiver.create(logger, backend);
+    final sender = await Sender.create(logger, backend);
+    return ModelRoot._create(backend, receiver, sender, packageInfo, logger);
   }
 }

--- a/lib/src/model/receiver.dart
+++ b/lib/src/model/receiver.dart
@@ -8,12 +8,13 @@ import '../agent.dart';
 part 'receiver.g.dart';
 
 /// Implementation of the Model Receiver class.
-class Receiver = _Receiver with _$Receiver;
+class Receiver extends _Receiver with _$Receiver {
+  Receiver._create(Logger logger, Backend backend) : super(logger, backend);
 
-class ReceiverFactory {
+  /// Public Receiver factory
   static Future<Receiver> create(Logger logger, Backend backend) async {
     var receiver = Receiver._create(logger, backend);
-    await receiver._setDefultValues();
+    await receiver._init();
     return receiver;
   }
 }
@@ -51,20 +52,28 @@ abstract class _Receiver with Store {
   @computed
   int get repairPort => _repairPort;
 
-  _Receiver._create(Logger logger, Backend backend)
-      : _logger = logger,
-        _backend = backend {
+  // Synchronous part of the constructor.
+  _Receiver(this._logger, this._backend) {
     // Subscribe to backend state change event.
     _backend.stateChangeEvent.subscribe(
       (args) async {
-        _isStarted = backend.receiverIsAlive;
+        _isStarted = _backend.receiverIsAlive;
       },
     );
   }
 
+  // Asynchronous part of the constructor.
+  @action
+  Future<void> _init() async {
+    _isStarted = _backend.receiverIsAlive;
+    _receiverIPs = ObservableList.of(await _backend.getLocalAddresses());
+    setSourcePort(10001);
+    setRepairPort(10002);
+  }
+
   // Start current receiver.
   @action
-  Future<void> requestAsyncStart() async {
+  Future<void> requestStart() async {
     await _backend.startReceiver(AndroidReceiverSettings(
       sourcePort: _sourcePort,
       repairPort: _repairPort,
@@ -73,7 +82,7 @@ abstract class _Receiver with Store {
 
   // Stop current receiver.
   @action
-  Future<void> requestAsyncStop() async {
+  Future<void> requestStop() async {
     await _backend.stopReceiver();
   }
 
@@ -89,14 +98,5 @@ abstract class _Receiver with Store {
   void setRepairPort(int value) {
     _repairPort = value;
     _logger.d('Receiver repair port value changed to: ${_repairPort}');
-  }
-
-  // Update all sender controls using "hardcoded" and default values.
-  @action
-  Future<void> _setDefultValues() async {
-    _isStarted = _backend.receiverIsAlive;
-    _receiverIPs = ObservableList.of(await _backend.getLocalAddresses());
-    setSourcePort(10001);
-    setRepairPort(10002);
   }
 }

--- a/lib/src/model/receiver.g.dart
+++ b/lib/src/model/receiver.g.dart
@@ -99,28 +99,28 @@ mixin _$Receiver on _Receiver, Store {
     });
   }
 
-  late final _$requestAsyncStartAsyncAction =
-      AsyncAction('_Receiver.requestAsyncStart', context: context);
+  late final _$_initAsyncAction =
+      AsyncAction('_Receiver._init', context: context);
 
   @override
-  Future<void> requestAsyncStart() {
-    return _$requestAsyncStartAsyncAction.run(() => super.requestAsyncStart());
+  Future<void> _init() {
+    return _$_initAsyncAction.run(() => super._init());
   }
 
-  late final _$requestAsyncStopAsyncAction =
-      AsyncAction('_Receiver.requestAsyncStop', context: context);
+  late final _$requestStartAsyncAction =
+      AsyncAction('_Receiver.requestStart', context: context);
 
   @override
-  Future<void> requestAsyncStop() {
-    return _$requestAsyncStopAsyncAction.run(() => super.requestAsyncStop());
+  Future<void> requestStart() {
+    return _$requestStartAsyncAction.run(() => super.requestStart());
   }
 
-  late final _$_setDefultValuesAsyncAction =
-      AsyncAction('_Receiver._setDefultValues', context: context);
+  late final _$requestStopAsyncAction =
+      AsyncAction('_Receiver.requestStop', context: context);
 
   @override
-  Future<void> _setDefultValues() {
-    return _$_setDefultValuesAsyncAction.run(() => super._setDefultValues());
+  Future<void> requestStop() {
+    return _$requestStopAsyncAction.run(() => super.requestStop());
   }
 
   late final _$_ReceiverActionController =

--- a/lib/src/model/sender.dart
+++ b/lib/src/model/sender.dart
@@ -7,12 +7,13 @@ import 'capture_source_type.dart';
 part 'sender.g.dart';
 
 /// Implementation of the Model Sender class.
-class Sender = _Sender with _$Sender;
+class Sender extends _Sender with _$Sender {
+  Sender._create(Logger logger, Backend backend) : super(logger, backend);
 
-class SenderFactory {
+  /// Public Sender factory
   static Future<Sender> create(Logger logger, Backend backend) async {
     var sender = Sender._create(logger, backend);
-    await sender._setDefultValues();
+    await sender._init();
     return sender;
   }
 }
@@ -57,20 +58,26 @@ abstract class _Sender with Store {
   @computed
   CaptureSourceType get captureSource => _captureSource;
 
-  _Sender._create(Logger logger, Backend backend)
-      : _logger = logger,
-        _backend = backend {
-    // Subscribe to backend state change event.
+  // Synchronous part of the constructor.
+  _Sender(this._logger, this._backend) {
     _backend.stateChangeEvent.subscribe(
       (args) async {
-        _isStarted = backend.senderIsAlive;
+        _isStarted = _backend.senderIsAlive;
       },
     );
   }
 
+  // Asynchronous part of the constructor.
+  @action
+  Future<void> _init() async {
+    _isStarted = _backend.senderIsAlive;
+    setSourcePort(10001);
+    setRepairPort(10002);
+  }
+
   // Start current sender.
   @action
-  Future<void> requestAsyncStart() async {
+  Future<void> requestStart() async {
     await _backend.startSender(AndroidSenderSettings(
       captureType: switch (captureSource) {
         CaptureSourceType.currentlyPlayingApplications =>
@@ -85,7 +92,7 @@ abstract class _Sender with Store {
 
   // Stop current sender.
   @action
-  Future<void> requestAsyncStop() async {
+  Future<void> requestStop() async {
     await _backend.stopSender();
   }
 
@@ -114,13 +121,5 @@ abstract class _Sender with Store {
   @action
   void setCaptureSource(CaptureSourceType value) {
     _captureSource = value;
-  }
-
-  // Update all sender controls using "hardcoded" and default values.
-  @action
-  Future<void> _setDefultValues() async {
-    _isStarted = _backend.senderIsAlive;
-    setSourcePort(10001);
-    setRepairPort(10002);
   }
 }

--- a/lib/src/model/sender.g.dart
+++ b/lib/src/model/sender.g.dart
@@ -121,28 +121,28 @@ mixin _$Sender on _Sender, Store {
     });
   }
 
-  late final _$requestAsyncStartAsyncAction =
-      AsyncAction('_Sender.requestAsyncStart', context: context);
+  late final _$_initAsyncAction =
+      AsyncAction('_Sender._init', context: context);
 
   @override
-  Future<void> requestAsyncStart() {
-    return _$requestAsyncStartAsyncAction.run(() => super.requestAsyncStart());
+  Future<void> _init() {
+    return _$_initAsyncAction.run(() => super._init());
   }
 
-  late final _$requestAsyncStopAsyncAction =
-      AsyncAction('_Sender.requestAsyncStop', context: context);
+  late final _$requestStartAsyncAction =
+      AsyncAction('_Sender.requestStart', context: context);
 
   @override
-  Future<void> requestAsyncStop() {
-    return _$requestAsyncStopAsyncAction.run(() => super.requestAsyncStop());
+  Future<void> requestStart() {
+    return _$requestStartAsyncAction.run(() => super.requestStart());
   }
 
-  late final _$_setDefultValuesAsyncAction =
-      AsyncAction('_Sender._setDefultValues', context: context);
+  late final _$requestStopAsyncAction =
+      AsyncAction('_Sender.requestStop', context: context);
 
   @override
-  Future<void> _setDefultValues() {
-    return _$_setDefultValuesAsyncAction.run(() => super._setDefultValues());
+  Future<void> requestStop() {
+    return _$requestStopAsyncAction.run(() => super.requestStop());
   }
 
   late final _$_SenderActionController =

--- a/lib/src/ui/main_screen.dart
+++ b/lib/src/ui/main_screen.dart
@@ -5,7 +5,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 
 import '../agent.dart';
-import '../model/model_root.dart';
+import '../model.dart';
 import 'components/roc_snackbar.dart';
 import 'fragments/roc_bottom_navigation_bar.dart';
 import 'pages/about_page.dart';

--- a/lib/src/ui/pages/about_page.dart
+++ b/lib/src/ui/pages/about_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../../model/model_root.dart';
+import '../../model.dart';
 import '../components/roc_scroll_view.dart';
 import '../styles/roc_colors.dart';
 

--- a/lib/src/ui/pages/receiver_page.dart
+++ b/lib/src/ui/pages/receiver_page.dart
@@ -4,7 +4,7 @@ import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 import 'package:logger/logger.dart';
 
-import '../../model/model_root.dart';
+import '../../model.dart';
 import '../components/roc_button.dart';
 import '../components/roc_chip.dart';
 import '../components/roc_page_view.dart';

--- a/lib/src/ui/pages/receiver_page.dart
+++ b/lib/src/ui/pages/receiver_page.dart
@@ -41,8 +41,8 @@ class ReceiverPage extends StatelessWidget {
       bottomButton: Observer(
         builder: (_) => RocButton(
           isActive: _modelRoot.receiver.isStarted,
-          deactivatedFunction: _modelRoot.receiver.requestAsyncStart,
-          activatedFunction: _modelRoot.receiver.requestAsyncStop,
+          deactivatedFunction: _modelRoot.receiver.requestStart,
+          activatedFunction: _modelRoot.receiver.requestStop,
           deactivatedText: AppLocalizations.of(context)!.startReceiverButton,
           activatedText: AppLocalizations.of(context)!.stopReceiverButton,
         ),

--- a/lib/src/ui/pages/sender_page.dart
+++ b/lib/src/ui/pages/sender_page.dart
@@ -56,8 +56,8 @@ class SenderPage extends StatelessWidget {
       bottomButton: Observer(
         builder: (_) => RocButton(
           isActive: _modelRoot.sender.isStarted,
-          deactivatedFunction: _modelRoot.sender.requestAsyncStart,
-          activatedFunction: _modelRoot.sender.requestAsyncStop,
+          deactivatedFunction: _modelRoot.sender.requestStart,
+          activatedFunction: _modelRoot.sender.requestStop,
           deactivatedText: AppLocalizations.of(context)!.startSenderButton,
           activatedText: AppLocalizations.of(context)!.stopSenderButton,
         ),

--- a/lib/src/ui/pages/sender_page.dart
+++ b/lib/src/ui/pages/sender_page.dart
@@ -3,8 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:flutter_mobx/flutter_mobx.dart';
 
-import '../../model/capture_source_type.dart';
-import '../../model/model_root.dart';
+import '../../model.dart';
 import '../components/roc_button.dart';
 import '../components/roc_chip.dart';
 import '../components/roc_dropdown_button.dart';

--- a/test/model/sender_test.dart
+++ b/test/model/sender_test.dart
@@ -20,7 +20,7 @@ void main() {
   test('Check the senders stop method when sender is not active.', () async {
     final sender = await testSender();
     expect(sender.isStarted, false);
-    await sender.requestAsyncStop();
+    await sender.requestStop();
     expect(sender.isStarted, false);
   });
 

--- a/test/test_helpers.dart
+++ b/test/test_helpers.dart
@@ -12,12 +12,12 @@ Future<ModelRoot> testModelRoot() async => await ModelRoot.create(
         version: 'Undefined',
         buildNumber: 'Undefined'));
 
-Future<Receiver> testReceiver() async => await ReceiverFactory.create(
+Future<Receiver> testReceiver() async => await Receiver.create(
       Logger(printer: SimplePrinter()),
       NoopBackend(),
     );
 
-Future<Sender> testSender() async => await SenderFactory.create(
+Future<Sender> testSender() async => await Sender.create(
       Logger(printer: SimplePrinter()),
       NoopBackend(),
     );


### PR DESCRIPTION
For #98.

Minor refactoring
- Simplify ModelRoot ctor.
- Don't use late when not needed.
- Replace SenderFactory and ReceiverFactory with
  static methods.
- Rename _setDefaultValues to _init()
- Rename requestAsyncStart() to requestStart(); "Async" is a
  bit confusing because it's not related to `async` keyword
- Remove public setters for receiverIsAlive and senderIsAlive
  in AndroidBackend
- Import model classes via model.dart