### PR TITLE
Android quicksettings tile for flutter (#106)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="org.rocstreaming.rocdroid"
           android:versionCode="3000"
           android:versionName="0.3.0">
   <!-- Numbers above are updated automatically by version_ctl.py.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -23,10 +23,26 @@
       android:name="${applicationName}"
       android:icon="@mipmap/launcher_icon">
 
+      <!-- Background service that handles streaming and persistent notification. -->
       <service
         android:name=".StreamingService"
         android:exported="false"
         android:foregroundServiceType="mediaProjection" />
+
+      <!-- Background service that handles quick settings tile button. -->
+      <service
+        android:name=".QuicktileService"
+        android:exported="true"
+        android:icon="@drawable/ic_notification"
+        android:label="@string/tile_label"
+        android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+        <meta-data
+          android:name="android.service.quicksettings.TOGGLEABLE_TILE"
+          android:value="true" />
+        <intent-filter>
+          <action android:name="android.service.quicksettings.action.QS_TILE" />
+        </intent-filter>
+      </service>
 
       <activity
         android:name=".MainActivity"

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/AndroidConnectorImpl.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/AndroidConnectorImpl.kt
@@ -36,8 +36,11 @@ class AndroidConnectorImpl : AndroidConnector {
         try {
             return NetworkInterface.getNetworkInterfaces().toList()
                 .flatMap { it.inetAddresses.toList() }
-                .filter { !it.isLoopbackAddress && !it.hostAddress.contains(':') }
-                .map { it.hostAddress }
+                .filter {
+                    it != null && !it.isLoopbackAddress &&
+                        it.hostAddress?.contains(':') == false
+                }
+                .mapNotNull { it.hostAddress }
         } catch (e: Exception) {
             Log.e(LOG_TAG, "Failed to retrieve address list: " + e.toString())
             return emptyList()

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/AndroidConnectorImpl.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/AndroidConnectorImpl.kt
@@ -28,7 +28,7 @@ private const val LOG_TAG = "rocdroid.AndroidConnectorImpl"
 class AndroidConnectorImpl : AndroidConnector {
     private var projectionAcquired: Boolean = false
 
-    fun getActivity(): MainActivity {
+    fun getMainActivity(): MainActivity {
         return MainActivity.instance
     }
 
@@ -50,7 +50,7 @@ class AndroidConnectorImpl : AndroidConnector {
     override fun requestNotifications(callback: (Result<Boolean>) -> Unit) {
         Log.i(LOG_TAG, "Requesting POST_NOTIFICATIONS permission")
 
-        getActivity().requestPermission(
+        getMainActivity().requestPermission(
             Manifest.permission.POST_NOTIFICATIONS,
             R.string.allow_notifications_title,
             R.string.allow_notifications_message,
@@ -70,7 +70,7 @@ class AndroidConnectorImpl : AndroidConnector {
     override fun requestMicrophone(callback: (Result<Boolean>) -> Unit) {
         Log.i(LOG_TAG, "Requesting RECORD_AUDIO permission")
 
-        getActivity().requestPermission(
+        getMainActivity().requestPermission(
             Manifest.permission.RECORD_AUDIO,
             R.string.allow_mic_title,
             R.string.allow_mic_message,
@@ -100,17 +100,17 @@ class AndroidConnectorImpl : AndroidConnector {
 
         // If service isn't started yet, start it and invoke callback when we've connected.
         // If service is already started, invoke callback immediately.
-        getActivity().startService({ service: StreamingService ->
+        getMainActivity().startStreamingService({ service: StreamingService ->
             // Ensure that service won't detach projection until releaseProjection().
             service.disableAutoDetach()
 
             if (service.hasProjection()) {
                 Log.d(LOG_TAG, "Projection already acquired")
                 callback(Result.success(true))
-                return@startService
+                return@startStreamingService
             }
 
-            getActivity().requestProjection({ projection: MediaProjection? ->
+            getMainActivity().requestProjection({ projection: MediaProjection? ->
                 if (projection == null) {
                     Log.w(LOG_TAG, "Projection request failed")
                     callback(Result.success(false))
@@ -134,7 +134,7 @@ class AndroidConnectorImpl : AndroidConnector {
 
         projectionAcquired = false
 
-        val service = getActivity().getService()
+        val service = getMainActivity().getStreamingService()
         if (service == null) {
             return
         }
@@ -151,7 +151,7 @@ class AndroidConnectorImpl : AndroidConnector {
             throw FlutterError(BAD_SEQUENCE_CODE, BAD_SEQUENCE_TEXT)
         }
 
-        val service = getActivity().getService()
+        val service = getMainActivity().getStreamingService()
         if (service == null) {
             Log.e(LOG_TAG, "Lost connection to service")
             throw FlutterError(NO_SERVICE_CODE, NO_SERVICE_TEXT)
@@ -168,7 +168,7 @@ class AndroidConnectorImpl : AndroidConnector {
     override fun stopReceiver() {
         Log.i(LOG_TAG, "Stopping receiver if needed")
 
-        val service = getActivity().getService()
+        val service = getMainActivity().getStreamingService()
         if (service == null) {
             Log.d(LOG_TAG, "Lost connection to service")
             return
@@ -178,7 +178,7 @@ class AndroidConnectorImpl : AndroidConnector {
     }
 
     override fun isReceiverAlive(): Boolean {
-        val service = getActivity().getService()
+        val service = getMainActivity().getStreamingService()
         if (service == null) {
             return false
         }
@@ -194,7 +194,7 @@ class AndroidConnectorImpl : AndroidConnector {
             throw FlutterError(BAD_SEQUENCE_CODE, BAD_SEQUENCE_TEXT)
         }
 
-        val service = getActivity().getService()
+        val service = getMainActivity().getStreamingService()
         if (service == null) {
             Log.e(LOG_TAG, "Lost connection to service")
             throw FlutterError(NO_SERVICE_CODE, NO_SERVICE_TEXT)
@@ -206,7 +206,7 @@ class AndroidConnectorImpl : AndroidConnector {
         }
 
         if (settings.captureType == AndroidCaptureType.CAPTURE_MIC &&
-            !getActivity().hasPermission(Manifest.permission.RECORD_AUDIO)
+            !getMainActivity().hasPermission(Manifest.permission.RECORD_AUDIO)
         ) {
             Log.e(LOG_TAG, "Microphone permission must be granted when using CAPTURE_MIC")
             throw FlutterError(NO_PERMISSION_CODE, NO_PERMISSION_TEXT)
@@ -218,7 +218,7 @@ class AndroidConnectorImpl : AndroidConnector {
     override fun stopSender() {
         Log.i(LOG_TAG, "Stopping sender if needed")
 
-        val service = getActivity().getService()
+        val service = getMainActivity().getStreamingService()
         if (service == null) {
             Log.d(LOG_TAG, "Lost connection to service")
             return
@@ -228,7 +228,7 @@ class AndroidConnectorImpl : AndroidConnector {
     }
 
     override fun isSenderAlive(): Boolean {
-        val service = getActivity().getService()
+        val service = getMainActivity().getStreamingService()
         if (service == null) {
             return false
         }

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
@@ -3,18 +3,13 @@ package org.rocstreaming.rocdroid
 import AndroidListener
 import AndroidServiceError
 import AndroidServiceEvent
-import android.app.ActivityManager
-import android.content.ComponentName
-import android.content.Context
 import android.content.Context.MEDIA_PROJECTION_SERVICE
 import android.content.Intent
-import android.content.ServiceConnection
 import android.content.pm.PackageManager
 import android.media.AudioManager
 import android.media.projection.MediaProjection
 import android.media.projection.MediaProjectionManager
 import android.os.Bundle
-import android.os.IBinder
 import android.util.Log
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -30,14 +25,6 @@ class MainActivity : FlutterFragmentActivity() {
     // main activity is a singleton used by AndroidConnectorImpl
     companion object {
         lateinit var instance: MainActivity
-    }
-
-    // non-null once successfully connected to server
-    // may temporarily become null when connection is lost
-    private var service: StreamingService? = null
-
-    fun getService(): StreamingService? {
-        return service
     }
 
     // called when we've started the service and connected to it
@@ -98,7 +85,7 @@ class MainActivity : FlutterFragmentActivity() {
         )
 
         // bind to service if it's running
-        bindRunningService()
+        streamingConnector.bindService()
     }
 
     // when app is resumed
@@ -113,52 +100,24 @@ class MainActivity : FlutterFragmentActivity() {
     override fun onDestroy() {
         Log.i(LOG_TAG, "Destroying main activity")
 
-        unbindService(serviceConnection)
+        streamingConnector.unbindService()
 
         super.onDestroy()
     }
 
-    // bind to service if it's running
-    fun bindRunningService() {
-        val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-
-        @Suppress("DEPRECATION")
-        val allServices = activityManager.getRunningServices(Integer.MAX_VALUE)
-
-        for (service in allServices) {
-            if (service.service.className == StreamingService::class.java.name) {
-                Log.d(LOG_TAG, "Found running service, binding")
-
-                val serviceIntent = Intent(this, StreamingService::class.java)
-                bindService(serviceIntent, serviceConnection, 0)
-
-                return
+    // handler for StreamingConnector events
+    private val streamingHandler: StreamingConnectionHandler = object : StreamingConnectionHandler {
+        override fun onConnected() {
+            // callback stored by startService()
+            val service = streamingConnector.getService()
+            if (service != null) {
+                serviceStartedCallback?.invoke(service)
+                serviceStartedCallback = null
+                // notify dart
+                emitEvent(AndroidServiceEvent.STREAMING_SERVICE_CONNECTED)
             }
         }
 
-        Log.d(LOG_TAG, "No running service found")
-    }
-
-    // start service if not started yet
-    fun startService(callback: (StreamingService) -> Unit) {
-        if (service != null) {
-            Log.d(LOG_TAG, "Service already started, nothing to do")
-            callback(service!!)
-            return
-        }
-
-        Log.d(LOG_TAG, "Starting service")
-
-        // callback will be invoked from onServiceConnected()
-        serviceStartedCallback = callback
-
-        val serviceIntent = Intent(this, StreamingService::class.java)
-        startForegroundService(serviceIntent)
-        bindService(serviceIntent, serviceConnection, BIND_AUTO_CREATE)
-    }
-
-    // handler for events produced by streaming service
-    private val streamingEventHandler: StreamingEventListener = object : StreamingEventListener {
         override fun onEvent(event: AndroidServiceEvent) {
             runOnUiThread {
                 // notify dart
@@ -172,43 +131,31 @@ class MainActivity : FlutterFragmentActivity() {
                 emitError(error)
             }
         }
-    }
 
-    // handler for connect & disconnect events
-    private val serviceConnection = object : ServiceConnection {
-        // called when we've successfully connected to the service
-        override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
-            Log.i(LOG_TAG, "Service connected")
-
-            // remember service reference
-            service = (binder as StreamingService.LocalBinder).getService()
-            service?.addEventListener(streamingEventHandler)
-
-            // for startService()
-            serviceStartedCallback?.invoke(service!!)
-            serviceStartedCallback = null
-
-            // notify dart
-            emitEvent(AndroidServiceEvent.STREAMING_SERVICE_CONNECTED)
-        }
-
-        // called when we've lost connectio to service
-        override fun onServiceDisconnected(componentName: ComponentName) {
-            Log.w(LOG_TAG, "Service disconnected")
-
-            // forget service reference
-            service?.removeEventListener(streamingEventHandler)
-            service = null
-
+        override fun onDisconnected() {
             // notify dart
             emitEvent(AndroidServiceEvent.STREAMING_SERVICE_DISCONNECTED)
-
-            // (re)start & reconnect
-            Log.d(LOG_TAG, "Initiating asynchronous reconnect")
-            val serviceIntent = Intent(this@MainActivity, StreamingService::class.java)
-            startForegroundService(serviceIntent)
-            bindService(serviceIntent, this, BIND_AUTO_CREATE)
         }
+    }
+
+    val streamingConnector = StreamingConnector(this, streamingHandler)
+
+    fun getStreamingService(): StreamingService? {
+        return streamingConnector.getService()
+    }
+
+    // start service if not started yet
+    fun startStreamingService(callback: (StreamingService) -> Unit) {
+        val service = streamingConnector.getService()
+        if (service != null) {
+            Log.d(LOG_TAG, "Service already started, nothing to do")
+            callback(service)
+            return
+        }
+
+        // callback will be invoked from onConnected()
+        serviceStartedCallback = callback
+        streamingConnector.startService()
     }
 
     fun requestProjection(callback: (MediaProjection?) -> Unit) {

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/MainActivity.kt
@@ -113,9 +113,7 @@ class MainActivity : FlutterFragmentActivity() {
     override fun onDestroy() {
         Log.i(LOG_TAG, "Destroying main activity")
 
-        if (serviceConnection != null) {
-            unbindService(serviceConnection)
-        }
+        unbindService(serviceConnection)
 
         super.onDestroy()
     }
@@ -123,7 +121,11 @@ class MainActivity : FlutterFragmentActivity() {
     // bind to service if it's running
     fun bindRunningService() {
         val activityManager = getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        for (service in activityManager.getRunningServices(Integer.MAX_VALUE)) {
+
+        @Suppress("DEPRECATION")
+        val allServices = activityManager.getRunningServices(Integer.MAX_VALUE)
+
+        for (service in allServices) {
             if (service.service.className == StreamingService::class.java.name) {
                 Log.d(LOG_TAG, "Found running service, binding")
 
@@ -279,11 +281,11 @@ class MainActivity : FlutterFragmentActivity() {
 
     private fun emitEvent(event: AndroidServiceEvent) {
         Log.d(LOG_TAG, "Sending event: " + event.toString())
-        eventListener.onEvent(event) { result -> }
+        eventListener.onEvent(event) { _ -> }
     }
 
     private fun emitError(error: AndroidServiceError) {
         Log.d(LOG_TAG, "Sending error: " + error.toString())
-        eventListener.onError(error) { result -> }
+        eventListener.onError(error) { _ -> }
     }
 }

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/QuicktileService.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/QuicktileService.kt
@@ -1,0 +1,159 @@
+package org.rocstreaming.rocdroid
+
+import AndroidServiceError
+import AndroidServiceEvent
+import android.app.PendingIntent
+import android.content.ComponentName
+import android.content.Intent
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import android.util.Log
+
+private const val LOG_TAG = "rocdroid.QuicktileService"
+
+class QuicktileService : TileService() {
+    private var isListening = false
+    private var pendingStop = false
+
+    // handler for StreamingConnector events
+    private val streamingHandler: StreamingConnectionHandler =
+        object : StreamingConnectionHandler {
+            override fun onConnected() {
+                if (pendingStop) {
+                    processStop()
+                }
+                updateTile()
+            }
+
+            override fun onEvent(event: AndroidServiceEvent) {
+                updateTile()
+            }
+
+            override fun onError(error: AndroidServiceError) {
+                updateTile()
+            }
+
+            override fun onDisconnected() {
+                updateTile()
+            }
+        }
+
+    val streamingConnector = StreamingConnector(this, streamingHandler)
+
+    override fun onCreate() {
+        Log.d(LOG_TAG, "Tile service created")
+
+        super.onCreate()
+
+        // bind to service if it's running
+        streamingConnector.bindService()
+    }
+
+    override fun onTileAdded() {
+        Log.d(LOG_TAG, "Tile added")
+
+        super.onTileAdded()
+
+        // start service if it's not running
+        streamingConnector.startService()
+    }
+
+    override fun onStartListening() {
+        Log.d(LOG_TAG, "Tile shown, setting listening to TRUE")
+
+        super.onStartListening()
+
+        // start service if it's not running
+        streamingConnector.startService()
+
+        isListening = true
+        updateTile()
+    }
+
+    override fun onClick() {
+        super.onClick()
+
+        if (this.qsTile.state == Tile.STATE_ACTIVE) {
+            processStop()
+        } else {
+            processStart()
+        }
+    }
+
+    override fun onStopListening() {
+        Log.d(LOG_TAG, "Tile hidden, setting listening to FALSE")
+
+        super.onStopListening()
+
+        isListening = false
+    }
+
+    override fun onTileRemoved() {
+        Log.d(LOG_TAG, "Tile removed")
+
+        super.onTileRemoved()
+
+        isListening = false
+    }
+
+    private fun processStart() {
+        // For now, when tile is switched on, we just open app.
+        // See gh-137.
+        Log.d(LOG_TAG, "Tile is switched ON, opening app")
+
+        pendingStop = false
+
+        if (isListening) {
+            qsTile.state = Tile.STATE_ACTIVE
+            qsTile.updateTile()
+        }
+
+        val intent = Intent().apply {
+            component = ComponentName(this@QuicktileService, MainActivity::class.java)
+            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            intent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+        startActivityAndCollapse(pendingIntent)
+    }
+
+    private fun processStop() {
+        if (isListening) {
+            qsTile.state = Tile.STATE_INACTIVE
+            qsTile.updateTile()
+        }
+
+        val service = streamingConnector.getService()
+        if (service == null) {
+            Log.d(LOG_TAG, "Not connected to streaming service")
+            pendingStop = true
+            return
+        }
+
+        pendingStop = false
+
+        service.stopSender()
+        service.stopReceiver()
+    }
+
+    private fun updateTile() {
+        if (isListening) {
+            val service = streamingConnector.getService()
+            val isRunning =
+                service != null && (service.isReceiverAlive() || service.isSenderAlive())
+
+            if (isRunning) {
+                Log.d(LOG_TAG, "Setting tile state to ACTIVE")
+                qsTile.state = Tile.STATE_ACTIVE
+            } else {
+                Log.d(LOG_TAG, "Setting tile state to INACTIVE")
+                qsTile.state = Tile.STATE_INACTIVE
+            }
+            qsTile.updateTile()
+        }
+    }
+}

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/StreamingConnector.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/StreamingConnector.kt
@@ -1,0 +1,118 @@
+package org.rocstreaming.rocdroid
+
+import AndroidServiceError
+import AndroidServiceEvent
+import android.app.ActivityManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.util.Log
+
+private const val LOG_TAG = "rocdroid.StreamingConnector"
+
+interface StreamingConnectionHandler {
+    fun onConnected()
+    fun onEvent(event: AndroidServiceEvent)
+    fun onError(error: AndroidServiceError)
+    fun onDisconnected()
+}
+
+class StreamingConnector(val context: Context, val handler: StreamingConnectionHandler) {
+    // non-null once successfully connected to server
+    // may temporarily become null when connection is lost
+    private var service: StreamingService? = null
+
+    fun getService(): StreamingService? {
+        return service
+    }
+
+    // bind to service if it's running
+    fun bindService() {
+        if (service != null) {
+            return
+        }
+
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+
+        @Suppress("DEPRECATION")
+        val allServices = activityManager.getRunningServices(Integer.MAX_VALUE)
+
+        for (service in allServices) {
+            if (service.service.className == StreamingService::class.java.name) {
+                Log.d(LOG_TAG, "Found running service, binding")
+
+                val serviceIntent = Intent(context, StreamingService::class.java)
+                context.bindService(serviceIntent, serviceHandler, 0)
+
+                return
+            }
+        }
+
+        Log.d(LOG_TAG, "No running service found")
+    }
+
+    // start service if not started yet
+    fun startService() {
+        if (service != null) {
+            return
+        }
+
+        Log.d(LOG_TAG, "Starting service")
+
+        val serviceIntent = Intent(context, StreamingService::class.java)
+        context.startForegroundService(serviceIntent)
+        context.bindService(serviceIntent, serviceHandler, Context.BIND_AUTO_CREATE)
+    }
+
+    // unbind service if bound
+    fun unbindService() {
+        Log.d(LOG_TAG, "Unbinding service")
+
+        context.unbindService(serviceHandler)
+        service = null
+    }
+
+    // handler for connect & disconnect events
+    private val serviceHandler =
+        object : ServiceConnection {
+            // called when we've successfully connected to the service
+            override fun onServiceConnected(componentName: ComponentName, binder: IBinder) {
+                Log.i(LOG_TAG, "Service connected")
+
+                // remember service reference
+                service = (binder as StreamingService.LocalBinder).getService()
+                service?.addEventListener(eventHandler)
+
+                handler.onConnected()
+            }
+
+            // called when we've lost connectio to service
+            override fun onServiceDisconnected(componentName: ComponentName) {
+                Log.w(LOG_TAG, "Service disconnected")
+
+                // forget service reference
+                service?.removeEventListener(eventHandler)
+                service = null
+
+                handler.onDisconnected()
+
+                // (re)start & reconnect
+                Log.d(LOG_TAG, "Initiating asynchronous reconnect")
+                startService()
+            }
+        }
+
+    // handler for events produced by streaming service
+    private val eventHandler: StreamingEventListener =
+        object : StreamingEventListener {
+            override fun onEvent(event: AndroidServiceEvent) {
+                handler.onEvent(event)
+            }
+
+            override fun onError(error: AndroidServiceError) {
+                handler.onError(error)
+            }
+        }
+}

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/StreamingService.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/StreamingService.kt
@@ -138,7 +138,7 @@ class StreamingService : Service() {
 
         Log.d(LOG_TAG, "Stopping service")
 
-        stopForeground(true)
+        stopForeground(STOP_FOREGROUND_REMOVE)
     }
 
     @Synchronized
@@ -428,7 +428,10 @@ class StreamingService : Service() {
         }
     }
 
-    private fun runReceiverThread(settings: AndroidReceiverSettings, projection: MediaProjection) {
+    private fun runReceiverThread(
+        settings: AndroidReceiverSettings,
+        @Suppress("UNUSED_PARAMETER") projection: MediaProjection
+    ) {
         Log.d(LOG_TAG, "Running receiver thread")
 
         var audioTrack: AudioTrack? = null

--- a/android/app/src/main/java/org/rocstreaming/rocdroid/StreamingService.kt
+++ b/android/app/src/main/java/org/rocstreaming/rocdroid/StreamingService.kt
@@ -45,10 +45,8 @@ private const val NOTIFICATION_ID = 1
 
 private const val NOTIFICATION_ACTION_DELETE =
     "org.rocstreaming.rocdroid.NotificationActionDelete"
-private const val NOTIFICATION_ACTION_STOP_SENDER =
-    "org.rocstreaming.rocdroid.NotificationActionStopSender"
-private const val NOTIFICATION_ACTION_STOP_RECEIVER =
-    "org.rocstreaming.rocdroid.NotificationActionStopReceiver"
+private const val NOTIFICATION_ACTION_STOP =
+    "org.rocstreaming.rocdroid.NotificationActionStop"
 
 private const val LOG_TAG = "rocdroid.StreamingService"
 
@@ -77,8 +75,10 @@ class StreamingService : Service() {
 
             when (intent.action) {
                 NOTIFICATION_ACTION_DELETE -> stopAllNoNotification()
-                NOTIFICATION_ACTION_STOP_SENDER -> stopSender()
-                NOTIFICATION_ACTION_STOP_RECEIVER -> stopReceiver()
+                NOTIFICATION_ACTION_STOP -> {
+                    stopSender()
+                    stopReceiver()
+                }
             }
         }
     }
@@ -592,8 +592,7 @@ class StreamingService : Service() {
             notificationActionHandler,
             IntentFilter().apply {
                 addAction(NOTIFICATION_ACTION_DELETE)
-                addAction(NOTIFICATION_ACTION_STOP_SENDER)
-                addAction(NOTIFICATION_ACTION_STOP_RECEIVER)
+                addAction(NOTIFICATION_ACTION_STOP)
             },
             RECEIVER_EXPORTED
         )
@@ -628,38 +627,25 @@ class StreamingService : Service() {
             PendingIntent.FLAG_IMMUTABLE
         )
 
-        // invoked when "stop sender" notification button is pressed
-        val stopSenderIntent = Intent(NOTIFICATION_ACTION_STOP_SENDER)
-        val pendingStopSenderIntent = PendingIntent.getBroadcast(
+        // invoked when "stop streaming" notification button is pressed
+        // we want to stop sender & receiver
+        val stopIntent = Intent(NOTIFICATION_ACTION_STOP)
+        val pendingStopIntent = PendingIntent.getBroadcast(
             this,
             0,
-            stopSenderIntent,
+            stopIntent,
             PendingIntent.FLAG_IMMUTABLE
         )
-        val stopSenderAction = Notification.Action.Builder(
+        val stopAction = Notification.Action.Builder(
             Icon.createWithResource(this@StreamingService, R.drawable.ic_stop),
-            getString(R.string.notification_stop_sender_action),
-            pendingStopSenderIntent
-        ).build()
-
-        // invoked when "stop receiver" notification button is pressed
-        val stopReceiverIntent = Intent(NOTIFICATION_ACTION_STOP_RECEIVER)
-        val pendingStopReceiverIntent = PendingIntent.getBroadcast(
-            this,
-            0,
-            stopReceiverIntent,
-            PendingIntent.FLAG_IMMUTABLE
-        )
-        val stopReceiverAction = Notification.Action.Builder(
-            Icon.createWithResource(this@StreamingService, R.drawable.ic_stop),
-            getString(R.string.notification_stop_receiver_action),
-            pendingStopReceiverIntent
+            getString(R.string.notification_stop_action),
+            pendingStopIntent
         ).build()
 
         return Notification.Builder(this, NOTIFICATION_CHANNEL_ID).apply {
             // appearance
             setSmallIcon(R.drawable.ic_notification)
-            setContentTitle(getString(R.string.notification_title))
+            setContentTitle(getNotificationTitle())
             setContentText(getNotificationText())
             // when notification is tapped
             setContentIntent(pendingContentIntent)
@@ -670,11 +656,8 @@ class StreamingService : Service() {
             // show on lock screen
             setVisibility(Notification.VISIBILITY_PUBLIC)
             // notification buttons
-            if (senderStarted) {
-                addAction(stopSenderAction)
-            }
-            if (receiverStarted) {
-                addAction(stopReceiverAction)
+            if (senderStarted || receiverStarted) {
+                addAction(stopAction)
             }
         }.build()
     }
@@ -687,6 +670,13 @@ class StreamingService : Service() {
             getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
+    private fun getNotificationTitle(): String {
+        return when {
+            senderStarted || receiverStarted -> getString(R.string.notification_title_active)
+            else -> getString(R.string.notification_title_inactive)
+        }
     }
 
     private fun getNotificationText(): String {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,4 +18,6 @@
     <string name="notification_title_active">Streaming active</string>
     <string name="notification_title_inactive">Streaming inactive</string>
     <string name="notification_stop_action">Stop streaming</string>
+
+    <string name="tile_label">Roc Droid</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -10,12 +10,12 @@
     <string name="allow_mic_title">Mic permission</string>
     <string name="allow_mic_message">The app needs permission to record audio from your phone mic.</string>
 
-    <string name="notification_channel_name">Sender and Receiver foreground service</string>
+    <string name="notification_channel_name">Streaming foreground service</string>
     <string name="notification_receiver_running">Receiver running</string>
     <string name="notification_sender_running">Sender running</string>
-    <string name="notification_sender_and_receiver_running">Sender and Receiver running</string>
-    <string name="notification_sender_and_receiver_not_running">Neither Sender or Receiver running</string>
-    <string name="notification_title">Roc State</string>
-    <string name="notification_stop_sender_action">Stop Sender</string>
-    <string name="notification_stop_receiver_action">Stop Receiver</string>
+    <string name="notification_sender_and_receiver_running">Sender and receiver running</string>
+    <string name="notification_sender_and_receiver_not_running">Neither sender or receiver running</string>
+    <string name="notification_title_active">Streaming active</string>
+    <string name="notification_title_inactive">Streaming inactive</string>
+    <string name="notification_stop_action">Stop streaming</string>
 </resources>

--- a/lib/src/agent/android_bridge.decl.dart
+++ b/lib/src/agent/android_bridge.decl.dart
@@ -1,10 +1,10 @@
 import 'package:pigeon/pigeon.dart';
 
-/// This file (android_connector.decl.dart) is not actually included into build and
+/// This file (android_bridge.decl.dart) is not actually included into build and
 /// is never imported by other dart code. It's only used during code generation to
 /// produce two other files:
-///  - android_connector.g.dart
-///  - AndroidConnector.g.kt
+///  - android_bridge.g.dart
+///  - AndroidBridge.g.kt
 @ConfigurePigeon(PigeonOptions(
   dartOut: 'lib/src/agent/android_bridge.g.dart',
   dartOptions: DartOptions(),
@@ -125,7 +125,7 @@ abstract class AndroidConnector {
   bool isSenderAlive();
 }
 
-/// Asynchronous events produces by android service.
+/// Asynchronous events produced by android service.
 enum AndroidServiceEvent {
   streamingServiceConnected,
   streamingServiceDisconnected,
@@ -133,7 +133,7 @@ enum AndroidServiceEvent {
   receiverStateChanged,
 }
 
-/// Asynchronous errors produces by android service.
+/// Asynchronous errors produced by android service.
 enum AndroidServiceError {
   audioRecordFailed,
   audioTrackFailed,


### PR DESCRIPTION
Changes:

- Fix kotlin warnings
- Simplify android notification
- Extract StreamingConnector class
- Reimplement android tile

Closes #106.

`quick_settings` flutter package was abandoned because of its limitations. Tile was re-implemented natively based on @linalinn code from #86.

There is one regression: new implementation can stop streaming, but can't start it, and instead opens the app. This limitation is caused by updating to new android API level. Hopefully we will overcome it later (after finishing migration to flutter). For further details, see #137.